### PR TITLE
Fix #20: No connection could be made because the target machine actively refused it

### DIFF
--- a/src/debugpy/adapter/__main__.py
+++ b/src/debugpy/adapter/__main__.py
@@ -50,7 +50,7 @@ def main(args):
         adapter.access_token = compat.force_str(codecs.encode(os.urandom(32), "hex"))
 
     try:
-        server_host, server_port = servers.listen()
+        server_host, server_port = servers.serve()
     except Exception as exc:
         if args.for_server is None:
             raise
@@ -58,7 +58,7 @@ def main(args):
     else:
         endpoints = {"server": {"host": server_host, "port": server_port}}
         try:
-            ide_host, ide_port = ide.listen(host=args.host, port=args.port)
+            ide_host, ide_port = ide.serve(args.host, args.port)
         except Exception as exc:
             if args.for_server is None:
                 raise
@@ -120,8 +120,8 @@ def main(args):
     # These must be registered after the one above, to ensure that the listener sockets
     # are closed before the endpoint info file is deleted - this way, another process
     # can wait for the file to go away as a signal that the ports are no longer in use.
-    atexit.register(servers.stop_listening)
-    atexit.register(ide.stop_listening)
+    atexit.register(servers.stop_serving)
+    atexit.register(ide.stop_serving)
 
     servers.wait_until_disconnected()
     log.info("All debug servers disconnected; waiting for remaining sessions...")

--- a/src/debugpy/adapter/ide.py
+++ b/src/debugpy/adapter/ide.py
@@ -13,7 +13,7 @@ from debugpy.common.compat import unicode
 from debugpy.adapter import components, servers, sessions
 
 
-class IDE(components.Component, sockets.ClientConnection):
+class IDE(components.Component):
     """Handles the IDE side of a debug session."""
 
     message_handler = components.Component.message_handler
@@ -450,7 +450,7 @@ class IDE(components.Component, sockets.ClientConnection):
         if "host" not in body:
             body["host"] = "127.0.0.1"
         if "port" not in body:
-            _, body["port"] = self.listener.getsockname()
+            _, body["port"] = listener.getsockname()
         if "processId" in body:
             del body["processId"]
         body["subProcessId"] = conn.pid
@@ -458,11 +458,14 @@ class IDE(components.Component, sockets.ClientConnection):
         self.channel.send_event("debugpyAttach", body)
 
 
-listen = IDE.listen
+def serve(host, port):
+    global listener
+    listener = sockets.serve("IDE", IDE, host, port)
+    return listener.getsockname()
 
 
-def stop_listening():
+def stop_serving():
     try:
-        IDE.listener.close()
+        listener.close()
     except Exception:
         log.exception(level="warning")

--- a/src/debugpy/adapter/launchers.py
+++ b/src/debugpy/adapter/launchers.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 from debugpy import adapter, launcher
-from debugpy.common import compat, log, messaging
+from debugpy.common import compat, log, messaging, sockets
 from debugpy.adapter import components, servers
 
 
@@ -71,64 +71,73 @@ def spawn_debuggee(session, start_request, sudo, args, console, console_title):
     cmdline += args
     env = {}
 
-    def spawn_launcher():
-        with session.accept_connection_from_launcher() as (_, launcher_port):
-            env[str("DEBUGPY_LAUNCHER_PORT")] = str(launcher_port)
-            if log.log_dir is not None:
-                env[str("DEBUGPY_LOG_DIR")] = compat.filename_str(log.log_dir)
-            if log.stderr.levels != {"warning", "error"}:
-                env[str("DEBUGPY_LOG_STDERR")] = str(" ".join(log.stderr.levels))
+    arguments = dict(start_request.arguments)
+    if not session.no_debug:
+        _, arguments["port"] = servers.listener.getsockname()
+        arguments["clientAccessToken"] = adapter.access_token
 
-            if console == "internalConsole":
-                log.info("{0} spawning launcher: {1!r}", session, cmdline)
+    def on_launcher_connected(sock):
+        listener.close()
+        stream = messaging.JsonIOStream.from_socket(sock)
+        Launcher(session, stream)
 
-                # If we are talking to the IDE over stdio, sys.stdin and sys.stdout are
-                # redirected to avoid mangling the DAP message stream. Make sure the
-                # launcher also respects that.
-                subprocess.Popen(
-                    cmdline,
-                    env=dict(list(os.environ.items()) + list(env.items())),
-                    stdin=sys.stdin,
-                    stdout=sys.stdout,
-                    stderr=sys.stderr,
-                )
+    listener = sockets.serve("Launcher", on_launcher_connected, "127.0.0.1", backlog=0)
+    try:
+        _, launcher_port = listener.getsockname()
 
-            else:
-                log.info('{0} spawning launcher via "runInTerminal" request.', session)
-                session.ide.capabilities.require("supportsRunInTerminalRequest")
-                kinds = {
-                    "integratedTerminal": "integrated",
-                    "externalTerminal": "external",
-                }
-                session.ide.channel.request(
-                    "runInTerminal",
-                    {
-                        "kind": kinds[console],
-                        "title": console_title,
-                        "args": cmdline,
-                        "env": env,
-                    },
-                )
+        env[str("DEBUGPY_LAUNCHER_PORT")] = str(launcher_port)
+        if log.log_dir is not None:
+            env[str("DEBUGPY_LOG_DIR")] = compat.filename_str(log.log_dir)
+        if log.stderr.levels != {"warning", "error"}:
+            env[str("DEBUGPY_LOG_STDERR")] = str(" ".join(log.stderr.levels))
+
+        if console == "internalConsole":
+            log.info("{0} spawning launcher: {1!r}", session, cmdline)
+
+            # If we are talking to the IDE over stdio, sys.stdin and sys.stdout are
+            # redirected to avoid mangling the DAP message stream. Make sure the
+            # launcher also respects that.
+            subprocess.Popen(
+                cmdline,
+                env=dict(list(os.environ.items()) + list(env.items())),
+                stdin=sys.stdin,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+            )
+
+        else:
+            log.info('{0} spawning launcher via "runInTerminal" request.', session)
+            session.ide.capabilities.require("supportsRunInTerminalRequest")
+            kinds = {
+                "integratedTerminal": "integrated",
+                "externalTerminal": "external",
+            }
+            session.ide.channel.request(
+                "runInTerminal",
+                {
+                    "kind": kinds[console],
+                    "title": console_title,
+                    "args": cmdline,
+                    "env": env,
+                },
+            )
+
+        if not session.wait_for(lambda: session.launcher, timeout=10):
+            raise start_request.cant_handle(
+                '{0} timed out waiting for {1} to connect',
+                session,
+                session.launcher,
+            )
 
         try:
             session.launcher.channel.request(start_request.command, arguments)
         except messaging.MessageHandlingError as exc:
             exc.propagate(start_request)
 
-    if session.no_debug:
-        arguments = start_request.arguments
-        spawn_launcher()
-    else:
-        _, port = servers.Connection.listener.getsockname()
-        arguments = dict(start_request.arguments)
-        arguments["port"] = port
-        arguments["clientAccessToken"] = adapter.access_token
-        spawn_launcher()
+        if session.no_debug:
+            return
 
-        if not session.wait_for(
-            lambda: session.launcher is not None and session.launcher.pid is not None,
-            timeout=5,
-        ):
+        if not session.wait_for(lambda: session.launcher.pid is not None, timeout=10):
             raise start_request.cant_handle(
                 '{0} timed out waiting for "process" event from {1}',
                 session,
@@ -143,3 +152,6 @@ def spawn_debuggee(session, start_request, sudo, args, console, console_title):
                 "{0} timed out waiting for debuggee to spawn", session
             )
         conn.attach_to_session(session)
+
+    finally:
+        listener.close()


### PR DESCRIPTION
Use max length for incoming connection queue for IDE and server connections to the adapter.

Clean up connection handling code:
- rename sockets.listen() helper to serve() to avoid confusion with socket.listen();
- simplify helper to not require inheritance;
- switch launcher to use the same helper as IDE and servers;
- remove unused legacy connection helpers in Session.