### PR TITLE
Fix https://github.com/microsoft/ptvsd/issues/2082

### DIFF
--- a/src/debugpy/adapter/sessions.py
+++ b/src/debugpy/adapter/sessions.py
@@ -65,7 +65,7 @@ class Session(util.Observable):
         self.observers += [lambda *_: self.notify_changed()]
 
     def __str__(self):
-        return fmt("Session-{0}", self.id)
+        return fmt("Session[{0}]", self.id)
 
     def __enter__(self):
         """Lock the session for exclusive access."""


### PR DESCRIPTION
Fix https://github.com/microsoft/ptvsd/issues/2082:
Failure to spawn ptvsd.launcher is not propagated to the client

Propagate errors from listener sockets, Popen(), and "runInTerminal" request back to the client.