### PR TITLE
Remove unused alternative syntax for "args"

### DIFF
--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -75,16 +75,16 @@ def launch_request(request):
 
     program = module = code = ()
     if "program" in request:
-        program = request("program", json.array(unicode, vectorize=True, size=(1,)))
-        cmdline += program
-        process_name = program[0]
+        program = request("program", unicode)
+        cmdline += [program]
+        process_name = program
     if "module" in request:
-        module = request("module", json.array(unicode, vectorize=True, size=(1,)))
-        cmdline += ["-m"] + module
-        process_name = module[0]
+        module = request("module", unicode)
+        cmdline += ["-m", module]
+        process_name = module
     if "code" in request:
         code = request("code", json.array(unicode, vectorize=True, size=(1,)))
-        cmdline += ["-c"] + code
+        cmdline += ["-c", "\n".join(code)]
         process_name = python[0]
 
     num_targets = len([x for x in (program, module, code) if x != ()])

--- a/tests/debug/targets.py
+++ b/tests/debug/targets.py
@@ -82,9 +82,8 @@ class Program(Target):
         return fmt("program {0!j}", self.filename)
 
     def configure(self, session):
-        session.config["program"] = (
-            [self.filename] + self.args if len(self.args) else self.filename
-        )
+        session.config["program"] = self.filename
+        session.config["args"] = self.args
 
     def cli(self, env):
         return [self.filename.strpath] + list(self.args)
@@ -108,9 +107,8 @@ class Module(Target):
         return fmt("module {0}", self.name)
 
     def configure(self, session):
-        session.config["module"] = (
-            [self.name] + self.args if len(self.args) else self.name
-        )
+        session.config["module"] = self.name
+        session.config["args"] = self.args
 
     def cli(self, env):
         if self.filename is not None:
@@ -137,9 +135,8 @@ class Code(Target):
         return fmt("code: {0!j}", lines)
 
     def configure(self, session):
-        session.config["code"] = (
-            [self.code] + self.args if len(self.args) else self.code
-        )
+        session.config["code"] = self.code
+        session.config["args"] = self.args
 
     def cli(self, env):
         return ["-c", self.code] + list(self.args)


### PR DESCRIPTION
Remove support for arrays in "program" and "module" debug configuration properties as alternative to "args".

Change the meaning of array for "code" debug configuration property to represent multiple lines of code.

Switch tests to use "args".