### PR TITLE
Preliminary support for Python 3.9. Fixes #35

### DIFF
--- a/src/debugpy/_vendored/pydevd/.travis.yml
+++ b/src/debugpy/_vendored/pydevd/.travis.yml
@@ -70,6 +70,7 @@ matrix:
         - PYDEVD_USE_CYTHON=YES
         - PYDEVD_TEST_VM=CPYTHON
         - CHECK_CYTHON_GENERATED=YES
+        - PYDEVD_USE_CONDA=NO
 
     - python: 3.8
       env:
@@ -77,6 +78,15 @@ matrix:
         - PYDEVD_USE_CYTHON=NO
         - PYDEVD_TEST_VM=CPYTHON
         - CHECK_CYTHON_GENERATED=YES
+        - PYDEVD_USE_CONDA=NO
+
+    # i.e.: https://www.python.org/download/pre-releases/
+    - python: 3.9-dev
+      env:
+        - PYDEVD_PYTHON_VERSION=3.9
+        - PYDEVD_USE_CYTHON=NO
+        - PYDEVD_TEST_VM=CPYTHON
+        - PYDEVD_USE_CONDA=NO
 
     - os: osx
       language: generic
@@ -96,9 +106,9 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo sysctl kernel.yama.ptrace_scope=0; fi
   # Both
   - export PYTHONPATH=.
-  # CPython setup (Note that for CPython 3.8 we'll use the system-installed version for now).
-  - if [[ ("$PYDEVD_TEST_VM" == "CPYTHON" && "$PYDEVD_PYTHON_VERSION" != "3.8") ]]; then conda create --yes -n build_env python=$PYDEVD_PYTHON_VERSION; fi
-  - if [[ ("$PYDEVD_TEST_VM" == "CPYTHON" && "$PYDEVD_PYTHON_VERSION" != "3.8") ]]; then source activate build_env; fi
+  # CPython setup
+  - if [[ ("$PYDEVD_TEST_VM" == "CPYTHON" && "$PYDEVD_USE_CONDA" != "NO") ]]; then conda create --yes -n build_env python=$PYDEVD_PYTHON_VERSION; fi
+  - if [[ ("$PYDEVD_TEST_VM" == "CPYTHON" && "$PYDEVD_USE_CONDA" != "NO") ]]; then source activate build_env; fi
   - if [[ ("$PYDEVD_TEST_VM" == "CPYTHON") ]]; then ./.travis/install_python_deps.sh; fi
   - if [[ ("$CHECK_CYTHON_GENERATED" == "YES") ]]; then python build_tools/build.py; fi
   # Check that we can compile just based on the .c files.
@@ -116,10 +126,7 @@ install:
 # On local machine with jython: c:\bin\jython2.7.0\bin\jython.exe -Dpython.path=.;jython_test_deps/ant.jar;jython_test_deps/junit.jar -m pytest
 # On remove machine with python: c:\bin\python27\python.exe -m pytest
 script:
-  # pytest-xdist not available for python == 2.6 and timing out without output with 2.7
-  - if [[ ("$PYDEVD_TEST_VM" == "CPYTHON") && ("$PYDEVD_PYTHON_VERSION" == "2.6" || "$PYDEVD_PYTHON_VERSION" == "2.7") ]]; then source activate build_env; python -m pytest; fi
-  - if [[ ("$PYDEVD_TEST_VM" == "CPYTHON") && ("$PYDEVD_PYTHON_VERSION" != "2.6" && "$PYDEVD_PYTHON_VERSION" != "2.7" && "$PYDEVD_PYTHON_VERSION" != "3.8") ]]; then source activate build_env; python -m pytest -n auto; fi
-  - if [[ ("$PYDEVD_TEST_VM" == "CPYTHON") && ("$PYDEVD_PYTHON_VERSION" == "3.8") ]]; then python -m pytest; fi
+  - if [[ ("$PYDEVD_TEST_VM" == "CPYTHON") ]]; then ./.travis/run_python_pytest.sh; fi
   - if [ "$PYDEVD_TEST_VM" == "PYPY" ]; then source activate build_env; pypy3 -m pytest -n auto; fi
   - if [ "$PYDEVD_TEST_VM" == "JYTHON" ]; then jython -Dpython.path=.:jython_test_deps/ant.jar:jython_test_deps/junit.jar -m pytest --tb=native; fi
 

--- a/src/debugpy/_vendored/pydevd/.travis/env_install.sh
+++ b/src/debugpy/_vendored/pydevd/.travis/env_install.sh
@@ -1,5 +1,5 @@
 # Setup for PyPy and versions pre 3.8 (for 3.8 we use the travis image).
-if [[ ("$PYDEVD_PYTHON_VERSION" != "3.8") && ("$PYDEVD_TEST_VM" == "CPYTHON" || "$PYDEVD_TEST_VM" == "PYPY") ]]; then
+if [[ ("$PYDEVD_USE_CONDA" != "NO") ]]; then
 
     export CONDA_URL=http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/src/debugpy/_vendored/pydevd/.travis/install_python_deps.sh
+++ b/src/debugpy/_vendored/pydevd/.travis/install_python_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ev
 
-if [[ ("$PYDEVD_PYTHON_VERSION" != "3.8" && "$PYDEVD_PYTHON_VERSION" != "2.6") ]]; then
+if [[ ("$PYDEVD_USE_CONDA" != "NO" && "$PYDEVD_PYTHON_VERSION" != "2.6") ]]; then
     source activate build_env
     conda install --yes numpy ipython pytest cython psutil
 fi
@@ -44,13 +44,26 @@ if [ "$PYDEVD_PYTHON_VERSION" = "3.7" ]; then
     pip install trio
 fi
 
-if [ "$PYDEVD_PYTHON_VERSION" = "3.8" ]; then
+if [[ ("$PYDEVD_PYTHON_VERSION" = "3.8") ]]; then
     pip install "pytest"
     pip install "cython"
     pip install "psutil"
     pip install "numpy"
     pip install trio
     pip install gevent
+
+    # Note: track the latest web framework versions.
+    pip install "django"
+    pip install "cherrypy"
+fi
+
+if [[ ("$PYDEVD_PYTHON_VERSION" = "3.9") ]]; then
+    pip install "pytest"
+    pip install "cython"
+    pip install "psutil"
+    pip install "numpy"
+    pip install trio
+    # pip install gevent -- not compatible with 3.9 for now.
 
     # Note: track the latest web framework versions.
     pip install "django"

--- a/src/debugpy/_vendored/pydevd/.travis/run_python_pytest.sh
+++ b/src/debugpy/_vendored/pydevd/.travis/run_python_pytest.sh
@@ -1,0 +1,12 @@
+if [[ "$PYDEVD_USE_CONDA" != "NO" ]]; then
+    source activate build_env
+fi
+
+if [[ ("$PYDEVD_PYTHON_VERSION" == "2.6" || "$PYDEVD_PYTHON_VERSION" == "2.7") ]]; then
+  # pytest-xdist not available for python == 2.6 and timing out without output with 2.7
+    python -m pytest
+
+else
+    python -m pytest -n auto
+
+fi

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_collect_bytecode_info.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_collect_bytecode_info.py
@@ -2,6 +2,7 @@ from opcode import HAVE_ARGUMENT, EXTENDED_ARG, hasconst, opname, hasname, hasjr
     hascompare, hasfree, cmp_op
 import dis
 import sys
+import inspect
 from collections import namedtuple
 from _pydevd_bundle.pydevd_constants import IS_PY38_OR_GREATER
 
@@ -75,7 +76,7 @@ def debug(s):
     pass
 
 
-_Instruction = namedtuple('_Instruction', 'opname, opcode, starts_line, argval, is_jump_target, offset')
+_Instruction = namedtuple('_Instruction', 'opname, opcode, starts_line, argval, is_jump_target, offset, argrepr')
 
 
 def _iter_as_bytecode_as_instructions_py2(co):
@@ -99,7 +100,7 @@ def _iter_as_bytecode_as_instructions_py2(co):
 
         i = i + 1
         if op < HAVE_ARGUMENT:
-            yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), None, is_jump_target, initial_bytecode_offset)
+            yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), None, is_jump_target, initial_bytecode_offset, '')
 
         else:
             oparg = ord(code[i]) + ord(code[i + 1]) * 256 + extended_arg
@@ -110,22 +111,22 @@ def _iter_as_bytecode_as_instructions_py2(co):
                 extended_arg = oparg * 65536
 
             if op in hasconst:
-                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), co.co_consts[oparg], is_jump_target, initial_bytecode_offset)
+                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), co.co_consts[oparg], is_jump_target, initial_bytecode_offset, repr(co.co_consts[oparg]))
             elif op in hasname:
-                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), co.co_names[oparg], is_jump_target, initial_bytecode_offset)
+                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), co.co_names[oparg], is_jump_target, initial_bytecode_offset, repr(co.co_names[oparg]))
             elif op in hasjrel:
                 argval = i + oparg
-                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), argval, is_jump_target, initial_bytecode_offset)
+                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), argval, is_jump_target, initial_bytecode_offset, "to " + repr(argval))
             elif op in haslocal:
-                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), co.co_varnames[oparg], is_jump_target, initial_bytecode_offset)
+                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), co.co_varnames[oparg], is_jump_target, initial_bytecode_offset, repr(co.co_varnames[oparg]))
             elif op in hascompare:
-                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), cmp_op[oparg], is_jump_target, initial_bytecode_offset)
+                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), cmp_op[oparg], is_jump_target, initial_bytecode_offset, cmp_op[oparg])
             elif op in hasfree:
                 if free is None:
                     free = co.co_cellvars + co.co_freevars
-                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), free[oparg], is_jump_target, initial_bytecode_offset)
+                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), free[oparg], is_jump_target, initial_bytecode_offset, repr(free[oparg]))
             else:
-                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), oparg, is_jump_target, initial_bytecode_offset)
+                yield _Instruction(curr_op_name, op, _get_line(op_offset_to_line, initial_bytecode_offset, 0), oparg, is_jump_target, initial_bytecode_offset, repr(oparg))
 
 
 def _iter_instructions(co):
@@ -230,3 +231,228 @@ def collect_try_except_info(co, use_func_first_line=False):
         del stack_in_setup[-1]
 
     return try_except_info_lst
+
+
+if sys.version_info[:2] >= (3, 9):
+
+    def collect_try_except_info(co, use_func_first_line=False):
+        # We no longer have 'END_FINALLY', so, we need to do things differently in Python 3.9
+        if not hasattr(co, 'co_lnotab'):
+            return []
+
+        if use_func_first_line:
+            firstlineno = co.co_firstlineno
+        else:
+            firstlineno = 0
+
+        try_except_info_lst = []
+
+        op_offset_to_line = dict(dis.findlinestarts(co))
+
+        offset_to_instruction_idx = {}
+
+        instructions = list(_iter_instructions(co))
+
+        line_to_instructions = {}
+
+        curr_line_index = firstlineno
+        for i, instruction in enumerate(instructions):
+            offset_to_instruction_idx[instruction.offset] = i
+
+            new_line_index = op_offset_to_line.get(instruction.offset)
+            if new_line_index is not None:
+                if new_line_index is not None:
+                    curr_line_index = new_line_index - firstlineno
+            line_to_instructions.setdefault(curr_line_index, []).append(instruction)
+
+        for i, instruction in enumerate(instructions):
+            curr_op_name = instruction.opname
+            if curr_op_name == 'SETUP_FINALLY':
+                exception_end_instruction_index = offset_to_instruction_idx[instruction.argval]
+
+                jump_instruction = instructions[exception_end_instruction_index - 1]
+                if jump_instruction.opname not in('JUMP_FORWARD', 'JUMP_ABSOLUTE'):
+                    continue
+
+                next_3 = [instruction.opname for instruction in instructions[exception_end_instruction_index:exception_end_instruction_index + 3]]
+                if next_3 == ['POP_TOP', 'POP_TOP', 'POP_TOP']:  # try..except without checking exception.
+
+                    if jump_instruction.opname == 'JUMP_ABSOLUTE':
+                        # On latest versions of Python 3 the interpreter has a go-backwards step,
+                        # used to show the initial line of a for/while, etc (which is this
+                        # JUMP_ABSOLUTE)... we're not really interested in it, but rather on where
+                        # it points to.
+                        except_end_instruction = instructions[offset_to_instruction_idx[jump_instruction.argval]]
+                        idx = offset_to_instruction_idx[except_end_instruction.argval]
+                        # Search for the POP_EXCEPT which should be at the end of the block.
+                        for pop_except_instruction in reversed(instructions[:idx]):
+                            if pop_except_instruction.opname == 'POP_EXCEPT':
+                                except_end_instruction = pop_except_instruction
+                                break
+                        else:
+                            continue  # i.e.: Continue outer loop
+
+                    else:
+                        except_end_instruction = instructions[offset_to_instruction_idx[jump_instruction.argval]]
+
+                elif next_3 and next_3[0] == 'DUP_TOP':  # try..except AssertionError.
+                    for jump_if_not_exc_instruction in instructions[exception_end_instruction_index + 1:]:
+                        if jump_if_not_exc_instruction.opname == 'JUMP_IF_NOT_EXC_MATCH':
+                            except_end_instruction = instructions[offset_to_instruction_idx[jump_if_not_exc_instruction.argval]]
+                            break
+                    else:
+                        continue  # i.e.: Continue outer loop
+
+                else:
+                    # i.e.: we're not interested in try..finally statements, only try..except.
+                    continue
+
+                try_except_info = TryExceptInfo(
+                    _get_line(op_offset_to_line, instruction.offset, firstlineno, search=True),
+                    is_finally=False
+                )
+                try_except_info.except_bytecode_offset = instruction.argval
+                try_except_info.except_line = _get_line(
+                    op_offset_to_line,
+                    try_except_info.except_bytecode_offset,
+                    firstlineno,
+                )
+
+                try_except_info.except_end_bytecode_offset = except_end_instruction.offset
+                try_except_info.except_end_line = _get_line(op_offset_to_line, except_end_instruction.offset, firstlineno, search=True)
+                try_except_info_lst.append(try_except_info)
+
+                for raise_instruction in instructions[i:offset_to_instruction_idx[try_except_info.except_end_bytecode_offset]]:
+                    if raise_instruction.opname == 'RAISE_VARARGS':
+                        if raise_instruction.argval == 0:
+                            try_except_info.raise_lines_in_except.append(
+                                _get_line(op_offset_to_line, raise_instruction.offset, firstlineno, search=True))
+
+        return try_except_info_lst
+
+
+class _Uncompyler(object):
+
+    def __init__(self, co, firstlineno):
+        self.co = co
+        self.firstlineno = firstlineno
+        self.instructions = list(_iter_instructions(co))
+
+    def _decorate_jump_target(self, instruction, instruction_repr):
+        if instruction.is_jump_target:
+            return '|%s|%s' % (instruction.offset, instruction_repr)
+
+        return instruction_repr
+
+    def _next_instruction_to_str(self, line_to_contents):
+        dec = self._decorate_jump_target
+
+        instruction = self.instructions.pop(0)
+        if instruction.opname in ('LOAD_GLOBAL', 'LOAD_FAST', 'LOAD_CONST'):
+            if self.instructions:
+                next_instruction = self.instructions[0]
+                if next_instruction.opname == 'STORE_FAST':
+                    self.instructions.pop(0)
+                    return '%s = %s' % (dec(next_instruction, next_instruction.argrepr), dec(instruction, instruction.argrepr))
+
+                if next_instruction.opname == 'CALL_FUNCTION':
+                    if next_instruction.argval == 0:
+                        self.instructions.pop(0)
+                        return dec(instruction, '%s()' % (instruction.argrepr))
+
+                if next_instruction.opname == 'RETURN_VALUE':
+                    self.instructions.pop(0)
+                    return dec(instruction, 'return %s' % (instruction.argrepr))
+
+                if next_instruction.opname == 'RAISE_VARARGS' and next_instruction.argval == 1:
+                    self.instructions.pop(0)
+                    return dec(next_instruction, 'raise %s' % dec(instruction, instruction.argrepr))
+
+        if instruction.opname == 'LOAD_CONST':
+            if inspect.iscode(instruction.argval):
+                code_line_to_contents = _Uncompyler(instruction.argval, self.firstlineno).build_line_to_contents()
+                for contents in code_line_to_contents.values():
+                    contents.insert(0, '    ')
+                line_to_contents.update(code_line_to_contents)
+
+        if instruction.opname == 'RAISE_VARARGS':
+            if instruction.argval == 0:
+                return 'raise'
+
+        if instruction.opname == 'SETUP_FINALLY':
+            return dec(instruction, 'try(%s):' % (instruction.argrepr,))
+
+        if instruction.argrepr:
+            return dec(instruction, '%s(%s)' % (instruction.opname, instruction.argrepr,))
+
+        if instruction.argval:
+            return dec(instruction, '%s{%s}' % (instruction.opname, instruction.argval,))
+
+        return dec(instruction, instruction.opname)
+
+    def build_line_to_contents(self):
+        co = self.co
+        firstlineno = self.firstlineno
+
+        # print('----')
+        # for instruction in self.instructions:
+        #     print(instruction)
+        # print('----\n\n')
+
+        op_offset_to_line = dict(dis.findlinestarts(co))
+        curr_line_index = 0
+
+        line_to_contents = {}
+
+        instructions = self.instructions
+        while instructions:
+            instruction = instructions[0]
+            new_line_index = op_offset_to_line.get(instruction.offset)
+            if new_line_index is not None:
+                if new_line_index is not None:
+                    curr_line_index = new_line_index - firstlineno
+
+            lst = line_to_contents.setdefault(curr_line_index, [])
+            lst.append(self._next_instruction_to_str(line_to_contents))
+        return line_to_contents
+
+    def uncompyle(self):
+        line_to_contents = self.build_line_to_contents()
+        from io import StringIO
+        stream = StringIO()
+        last_line = 0
+        for line, contents in line_to_contents.items():
+            while last_line < line - 1:
+                stream.write(u'%s.\n' % (last_line + 1,))
+                last_line += 1
+
+            if contents and not contents[0].strip():
+                # i.e.: don't put a comma after the indentation.
+                stream.write(u'%s. %s%s\n' % (line, contents[0], ', '.join(contents[1:])))
+            else:
+                stream.write(u'%s. %s\n' % (line, ', '.join(contents)))
+            last_line = line
+
+        return stream.getvalue()
+
+
+def uncompyle(co, use_func_first_line=False):
+    '''
+    A simple uncompyle of bytecode.
+
+    It does not attempt to provide a full uncompyle to Python, rather, it provides a low-level
+    representation of the bytecode, respecting the lines (so, its target is making the bytecode
+    easier to grasp and not providing the original source code).
+
+    Note that it does show jump locations/targets and converts some common bytecode constructs to
+    Python code to make it a bit easier to understand.
+    '''
+    # Reference for bytecodes:
+    # https://docs.python.org/3/library/dis.html
+    if use_func_first_line:
+        firstlineno = co.co_firstlineno
+    else:
+        firstlineno = 0
+
+    return _Uncompyler(co, firstlineno).uncompyle()
+

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_constants.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_constants.py
@@ -113,6 +113,7 @@ IS_PY34_OR_GREATER = False
 IS_PY36_OR_GREATER = False
 IS_PY37_OR_GREATER = False
 IS_PY38_OR_GREATER = False
+IS_PY39_OR_GREATER = False
 IS_PY2 = True
 IS_PY27 = False
 IS_PY24 = False
@@ -124,6 +125,7 @@ try:
         IS_PY36_OR_GREATER = sys.version_info >= (3, 6)
         IS_PY37_OR_GREATER = sys.version_info >= (3, 7)
         IS_PY38_OR_GREATER = sys.version_info >= (3, 8)
+        IS_PY39_OR_GREATER = sys.version_info >= (3, 9)
     elif sys.version_info[0] == 2 and sys.version_info[1] == 7:
         IS_PY27 = True
     elif sys.version_info[0] == 2 and sys.version_info[1] == 4:

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch_regular.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch_regular.py
@@ -322,8 +322,6 @@ class TopLevelThreadTracerNoBackFrame(object):
                                             # match the raised exception.
                                             py_db.stop_on_unhandled_exception(py_db, t, additional_info, self._last_exc_arg)
                                             break
-                                        else:
-                                            break  # exited during the except block (no exception raised)
             finally:
                 # Remove reference to exception after handling it.
                 self._last_exc_arg = None

--- a/src/debugpy/_vendored/pydevd/tests/test_pyserver.py
+++ b/src/debugpy/_vendored/pydevd/tests/test_pyserver.py
@@ -109,7 +109,8 @@ class TestCPython(unittest.TestCase):
                 'math.cpython-35m' in completions or
                 'math.cpython-36m' in completions or
                 'math.cpython-37m' in completions or
-                'math.cpython-38' in completions
+                'math.cpython-38' in completions or
+                'math.cpython-39' in completions
                 ):
                 return
             self.assertTrue(completions.startswith(start) or completions.startswith(start_2), '%s DOESNT START WITH %s' % (completions, (start, start_2)))

--- a/src/debugpy/_vendored/pydevd/tests_python/test_collect_bytecode_info/test_collect_try_except_info.json
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_collect_bytecode_info/test_collect_try_except_info.json
@@ -28,7 +28,7 @@
         "{try:1 except 3 end block 4}"
     ],
     "_method_try_except": [
-        "{try:2 except 4 end block 5 raises: 5}",
-        "{try:1 except 6 end block 9 raises: 5}"
+        "{try:1 except 6 end block 9 raises: 5}",
+        "{try:2 except 4 end block 5 raises: 5}"
     ]
 }

--- a/src/debugpy/_vendored/pydevd/tests_python/test_debugger.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_debugger.py
@@ -18,7 +18,7 @@ from tests_python.debugger_unittest import (CMD_SET_PROPERTY_TRACE, REASON_CAUGH
     CMD_THREAD_SUSPEND, CMD_STEP_OVER, REASON_STEP_OVER, CMD_THREAD_SUSPEND_SINGLE_NOTIFICATION,
     CMD_THREAD_RESUME_SINGLE_NOTIFICATION, REASON_STEP_RETURN, REASON_STEP_RETURN_MY_CODE,
     REASON_STEP_OVER_MY_CODE, REASON_STEP_INTO, CMD_THREAD_KILL, IS_PYPY, REASON_STOP_ON_START)
-from _pydevd_bundle.pydevd_constants import IS_WINDOWS, IS_PY38_OR_GREATER
+from _pydevd_bundle.pydevd_constants import IS_WINDOWS, IS_PY38_OR_GREATER, IS_PY39_OR_GREATER
 from _pydevd_bundle.pydevd_comm_constants import CMD_RELOAD_CODE
 import json
 import pydevd_file_utils
@@ -2629,7 +2629,8 @@ def test_attach_to_pid_no_threads(case_setup_remote, reattach):
         writer.finished_ok = True
 
 
-@pytest.mark.skipif(not IS_CPYTHON, reason='CPython only test.')
+@pytest.mark.skipif(not IS_CPYTHON or IS_PY39_OR_GREATER, reason='CPython only test.'
+                    '3.9: still needs support to attach to pid (waiting for CPython api to stabilize)')
 def test_attach_to_pid_halted(case_setup_remote):
     with case_setup_remote.test_file('_debugger_case_attach_to_pid_multiple_threads.py', wait_for_port=False) as writer:
         time.sleep(1)  # Give it some time to initialize and get to the proper halting condition
@@ -2672,7 +2673,8 @@ def test_remote_debugger_basic(case_setup_remote):
         writer.finished_ok = True
 
 
-@pytest.mark.skipif(not IS_CPYTHON, reason='CPython only test.')
+@pytest.mark.skipif(not IS_CPYTHON or IS_PY39_OR_GREATER, reason='CPython only test.'
+                    '3.9: still needs support to trace other threads (waiting for CPython api to stabilize).')
 def test_remote_debugger_threads(case_setup_remote):
     with case_setup_remote.test_file('_debugger_case_remote_threads.py') as writer:
         writer.write_make_initial_run()

--- a/src/debugpy/_vendored/pydevd/tests_python/test_debugger_json.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_debugger_json.py
@@ -16,7 +16,7 @@ from _pydevd_bundle._debug_adapter.pydevd_schema import (ThreadEvent, ModuleEven
     InitializeRequestArguments, TerminateArguments, TerminateRequest, TerminatedEvent)
 from _pydevd_bundle.pydevd_comm_constants import file_system_encoding
 from _pydevd_bundle.pydevd_constants import (int_types, IS_64BIT_PROCESS,
-    PY_VERSION_STR, PY_IMPL_VERSION_STR, PY_IMPL_NAME, IS_PY36_OR_GREATER)
+    PY_VERSION_STR, PY_IMPL_VERSION_STR, PY_IMPL_NAME, IS_PY36_OR_GREATER, IS_PY39_OR_GREATER)
 from tests_python import debugger_unittest
 from tests_python.debug_constants import TEST_CHERRYPY, IS_PY2, TEST_DJANGO, TEST_FLASK, IS_PY26, \
     IS_PY27, IS_CPYTHON, TEST_GEVENT
@@ -2631,7 +2631,8 @@ def test_source_mapping(case_setup):
         writer.finished_ok = True
 
 
-@pytest.mark.skipif(not TEST_CHERRYPY, reason='No CherryPy available')
+@pytest.mark.skipif(not TEST_CHERRYPY or IS_PY39_OR_GREATER, reason='No CherryPy available.'
+                    'Must investigate support on Python 3.9')
 def test_process_autoreload_cherrypy(case_setup_multiprocessing, tmpdir):
     '''
     CherryPy does an os.execv(...) which will kill the running process and replace

--- a/src/debugpy/_vendored/pydevd/tests_python/test_tracing_on_top_level.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_tracing_on_top_level.py
@@ -476,6 +476,7 @@ def test_tracing_on_top_level_unhandled(trace_top_level_unhandled, func):
     trace_top_level_unhandled.set_target_func(func)
 
     collected_events = _collect_events(func)
+    # print([(x[0], x[1], x[2].__class__.__name__) for x in collected_events])
     _replay_events(collected_events, trace_top_level_unhandled)
 
     if func.__handled__:

--- a/src/debugpy/_vendored/pydevd/tests_python/test_utilities.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_utilities.py
@@ -4,7 +4,7 @@ from _pydevd_bundle.pydevd_comm import pydevd_find_thread_by_id
 from _pydevd_bundle.pydevd_utils import convert_dap_log_message_to_expression
 from tests_python.debug_constants import IS_PY26, IS_PY3K, TEST_GEVENT
 import sys
-from _pydevd_bundle.pydevd_constants import IS_CPYTHON, IS_WINDOWS, IS_PY2
+from _pydevd_bundle.pydevd_constants import IS_CPYTHON, IS_WINDOWS, IS_PY2, IS_PY39_OR_GREATER
 import pytest
 import os
 import codecs
@@ -28,6 +28,7 @@ def test_expression_to_evaluate():
 
 def test_is_main_thread():
     from _pydevd_bundle.pydevd_utils import is_current_thread_main_thread
+    from _pydevd_bundle.pydevd_utils import dump_threads
     if not is_current_thread_main_thread():
         error_msg = 'Current thread does not seem to be a main thread. Details:\n'
         current_thread = threading.current_thread()
@@ -39,6 +40,14 @@ def test_is_main_thread():
             error_msg += 'Current main thread not instance of: %s (%s)' % (
                 threading._MainThread, current_thread.__class__.__mro__,)
 
+        try:
+            from StringIO import StringIO
+        except:
+            from io import StringIO
+
+        stream = StringIO()
+        dump_threads(stream=stream)
+        error_msg += '\n\n' + stream.getvalue()
         raise AssertionError(error_msg)
 
     class NonMainThread(threading.Thread):
@@ -307,14 +316,16 @@ def _check_in_separate_process(method_name, module_name='test_utilities', update
     )
 
 
-@pytest.mark.skipif(not IS_CPYTHON, reason='Functionality to trace other threads requires CPython.')
+@pytest.mark.skipif(not IS_CPYTHON or IS_PY39_OR_GREATER, reason='Functionality to trace other threads requires CPython.'
+                    '3.9: still needs support to tracing other threads (waiting for CPython api to stabilize)')
 def test_tracing_other_threads():
     # Note: run this test in a separate process so that it doesn't mess with any current tracing
     # in our current process.
     _check_in_separate_process('_check_tracing_other_threads')
 
 
-@pytest.mark.skipif(not IS_CPYTHON, reason='Functionality to trace other threads requires CPython.')
+@pytest.mark.skipif(not IS_CPYTHON or IS_PY39_OR_GREATER, reason='Functionality to trace other threads requires CPython.'
+                    '3.9: still needs support to tracing other threads (waiting for CPython api to stabilize)')
 def test_find_main_thread_id():
     # Note: run the checks below in a separate process because they rely heavily on what's available
     # in the env (such as threads or having threading imported).


### PR DESCRIPTION
Some notes:

- This is not 100% support for Python 3.9, so, features which require on the C-API will still need work -- i.e.: attach to process, set tracing to different threads (because the C-API is unstable there's not much point in fixing it now and having to fix it again in the short-term future -- I plan on taking a look at that after the 2nd beta comes out and cython is able to compile with it -- which according to https://www.python.org/dev/peps/pep-0596/ is around 2020-06-08) -- I still think it was worth the effort to port the bytecode support for Python 3.9 because the new code follows jumps to gather try..except info for dealing with handled/unhandled exceptions at the top level (so, I don't think it'll break as the old code did and even if it does break it **should** be easier to fix in that structure).

- I added some utilities for showing bytecode respecting lines as most of the breakage was due to changes in bytecode and following it with `dis.dis` wasn't ideal (maybe we could use that when we don't have the source code as it respects the lines, so, they should match what we have in the debugger -- we can't use uncompyle6 because its license is GPL -- i.e.: https://github.com/microsoft/ptvsd/issues/1304).
