### PR TITLE
Keep order of items in dictionary (Py3.6 onwards) or odict. 

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_resolver.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_resolver.py
@@ -8,7 +8,7 @@ import traceback
 from os.path import basename
 
 from functools import partial
-from _pydevd_bundle.pydevd_constants import dict_iter_items, dict_keys, xrange
+from _pydevd_bundle.pydevd_constants import dict_iter_items, dict_keys, xrange, IS_PY36_OR_GREATER
 from _pydevd_bundle.pydevd_safe_repr import SafeRepr
 
 # Note: 300 is already a lot to see in the outline (after that the user should really use the shell to get things)
@@ -241,6 +241,8 @@ class DefaultResolver:
 #=======================================================================================================================
 class DictResolver:
 
+    sort_keys = not IS_PY36_OR_GREATER
+
     def resolve(self, dict, key):
         if key in ('__len__', TOO_LARGE_ATTR):
             return None
@@ -301,6 +303,9 @@ class DictResolver:
 
         if from_default_resolver:
             ret = from_default_resolver + ret
+
+        if not self.sort_keys:
+            return ret
 
         return sorted(ret, key=lambda tup: sorted_attributes_key(tup[0]))
 
@@ -579,6 +584,8 @@ class DequeResolver(TupleResolver):
 # OrderedDictResolver
 #=======================================================================================================================
 class OrderedDictResolver(DictResolver):
+
+    sort_keys = False
 
     def init_dict(self):
         return OrderedDict()

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_xml.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_xml.py
@@ -46,6 +46,13 @@ def _create_default_type_map():
         (dict, pydevd_resolver.dictResolver),
     ]
     try:
+        from collections import OrderedDict
+        default_type_map.insert(0, (OrderedDict, pydevd_resolver.orderedDictResolver))
+        # we should put it before dict
+    except:
+        pass
+
+    try:
         default_type_map.append((long, None))  # @UndefinedVariable
     except:
         pass  # not available on all python versions

--- a/src/debugpy/_vendored/pydevd/tests_python/resources/_debugger_case_odict.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/resources/_debugger_case_odict.py
@@ -1,0 +1,14 @@
+def check():
+    from collections import OrderedDict
+    import sys
+    # On 3.6 onwards, use a regular dict.
+    odict = OrderedDict() if sys.version_info[:2] < (3, 6) else {}
+    odict[4] = 'first'
+    odict[3] = 'second'
+    odict[2] = 'last'
+    print('break here')
+
+
+if __name__ == '__main__':
+    check()
+print('TEST SUCEEDED')

--- a/src/debugpy/_vendored/pydevd/tests_python/test_resolvers.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_resolvers.py
@@ -1,4 +1,5 @@
 from tests_python.debug_constants import IS_PY2
+from _pydevd_bundle.pydevd_constants import IS_PY36_OR_GREATER
 
 
 def check_len_entry(len_entry, first_2_params):
@@ -14,7 +15,11 @@ def test_dict_resolver():
     contents_debug_adapter_protocol = dict_resolver.get_contents_debug_adapter_protocol(dct)
     len_entry = contents_debug_adapter_protocol.pop(-1)
     check_len_entry(len_entry, ('__len__', 2))
-    if IS_PY2:
+    if IS_PY36_OR_GREATER:
+        assert contents_debug_adapter_protocol == [
+            ('(1, 2)', 2, '[(1, 2)]'), ("'22'", 22, "['22']")]
+
+    elif IS_PY2:
         assert contents_debug_adapter_protocol == [
             ('(1, 2)', 2, '[(1, 2)]'), (u"u'22'", 22, u"[u'22']")]
     else:

--- a/tests/debugpy/test_evaluate.py
+++ b/tests/debugpy/test_evaluate.py
@@ -166,7 +166,10 @@ def test_variable_sort(pyfile, target, run):
             "variables", {"variablesReference": b_test["variablesReference"]}
         )["variables"]
         var_names = [v["name"] for v in b_test_vars]
-        assert var_names == ["'abcd'", "'eggs'", "'spam'", "__len__"]
+        if sys.version_info[:2] >= (3, 6):
+            assert var_names == ["'spam'", "'eggs'", "'abcd'", "__len__"]
+        else:
+            assert var_names == ["'abcd'", "'eggs'", "'spam'", "__len__"]
 
         # Numeric dict keys must be sorted as numbers.
         if not "https://github.com/microsoft/ptvsd/issues/213":
@@ -394,45 +397,89 @@ def test_hex_numbers(pyfile, target, run):
             "variables",
             {"variablesReference": c["variablesReference"], "format": {"hex": True}},
         )["variables"]
-        assert c_vars == [
-            some.dict.containing(
-                {
-                    "name": "0x3e8",
-                    "value": "0x3e8",
-                    "type": "int",
-                    "evaluateName": "c[1000]",
-                    "variablesReference": 0,
-                }
-            ),
-            some.dict.containing(
-                {
-                    "name": "0x64",
-                    "value": "0x64",
-                    "type": "int",
-                    "evaluateName": "c[100]",
-                    "variablesReference": 0,
-                }
-            ),
-            some.dict.containing(
-                {
-                    "name": "0xa",
-                    "value": "0xa",
-                    "type": "int",
-                    "evaluateName": "c[10]",
-                    "variablesReference": 0,
-                }
-            ),
-            some.dict.containing(
-                {
-                    "name": "__len__",
-                    "value": "0x3",
-                    "type": "int",
-                    "evaluateName": "len(c)",
-                    "variablesReference": 0,
-                    "presentationHint": {"attributes": ["readOnly"]},
-                }
-            ),
-        ]
+        if sys.version_info[:2] < (3, 6):
+            # Sorted dict keys by the name before Python 3.6.
+            assert c_vars == [
+                some.dict.containing(
+                    {
+                        "name": "0x3e8",
+                        "value": "0x3e8",
+                        "type": "int",
+                        "evaluateName": "c[1000]",
+                        "variablesReference": 0,
+                    }
+                ),
+                some.dict.containing(
+                    {
+                        "name": "0x64",
+                        "value": "0x64",
+                        "type": "int",
+                        "evaluateName": "c[100]",
+                        "variablesReference": 0,
+                    }
+                ),
+                some.dict.containing(
+                    {
+                        "name": "0xa",
+                        "value": "0xa",
+                        "type": "int",
+                        "evaluateName": "c[10]",
+                        "variablesReference": 0,
+                    }
+                ),
+                some.dict.containing(
+                    {
+                        "name": "__len__",
+                        "value": "0x3",
+                        "type": "int",
+                        "evaluateName": "len(c)",
+                        "variablesReference": 0,
+                        "presentationHint": {"attributes": ["readOnly"]},
+                    }
+                ),
+            ]
+        else:
+            # Use dict sequence on Python 3.6 onwards.
+            assert c_vars == [
+                some.dict.containing(
+                    {
+                        "name": "0xa",
+                        "value": "0xa",
+                        "type": "int",
+                        "evaluateName": "c[10]",
+                        "variablesReference": 0,
+                    }
+                ),
+                some.dict.containing(
+                    {
+                        "name": "0x64",
+                        "value": "0x64",
+                        "type": "int",
+                        "evaluateName": "c[100]",
+                        "variablesReference": 0,
+                    }
+                ),
+                some.dict.containing(
+                    {
+                        "name": "0x3e8",
+                        "value": "0x3e8",
+                        "type": "int",
+                        "evaluateName": "c[1000]",
+                        "variablesReference": 0,
+                    }
+                ),
+                some.dict.containing(
+                    {
+                        "name": "__len__",
+                        "value": "0x3",
+                        "type": "int",
+                        "evaluateName": "len(c)",
+                        "variablesReference": 0,
+                        "presentationHint": {"attributes": ["readOnly"]},
+                    }
+                ),
+            ]
+
 
         d_vars = session.request(
             "variables",


### PR DESCRIPTION
Fixes https://github.com/microsoft/ptvsd/issues/998