### PR TITLE
Fix #90: "subProcess" is not respected

### DIFF
--- a/src/debugpy/__init__.py
+++ b/src/debugpy/__init__.py
@@ -84,7 +84,10 @@ def configure(properties=None, **kwargs):
 
         debugpy.configure({"subProcess": False})
     """
-    pass
+
+    from debugpy.server import api
+
+    return api.configure(properties, **kwargs)
 
 
 def listen(address):

--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -67,6 +67,8 @@ def launch_request(request):
             "--connect",
             str(port),
         ]
+        if not request("subProcess", True):
+            cmdline += ["--configure-subProcess", "False"]
         adapter_access_token = request("adapterAccessToken", unicode, optional=True)
         if adapter_access_token != ():
             cmdline += ["--adapter-access-token", compat.filename(adapter_access_token)]

--- a/src/debugpy/server/api.py
+++ b/src/debugpy/server/api.py
@@ -107,6 +107,7 @@ def _starts_debugging(func):
 
         ensure_logging()
         log.debug("{0}({1!r}, **{2!r})", func.__name__, address, kwargs)
+        log.info("Initial debug configuration: {0!j}", _config)
 
         settrace_kwargs = {
             "suspend": False,

--- a/tests/debugpy/test_multiproc.py
+++ b/tests/debugpy/test_multiproc.py
@@ -159,7 +159,8 @@ def test_multiprocessing(pyfile, target, run, start_method):
                 parent_backchannel.send("continue")
 
 
-def test_subprocess(pyfile, target, run):
+@pytest.mark.parametrize("subProcess", [True, False, None])
+def test_subprocess(pyfile, target, run, subProcess):
     @pyfile
     def child():
         import os
@@ -195,6 +196,8 @@ def test_subprocess(pyfile, target, run):
 
     with debug.Session() as parent_session:
         backchannel = parent_session.open_backchannel()
+        if subProcess is not None:
+            parent_session.config["subProcess"] = subProcess
 
         with run(parent_session, target(parent, args=[child])):
             pass
@@ -212,6 +215,9 @@ def test_subprocess(pyfile, target, run):
                 }
             }
         )
+
+        if subProcess is False:
+            return
 
         child_config = parent_session.wait_for_next_event("debugpyAttach")
         assert child_config == expected_child_config


### PR DESCRIPTION
Propagate "subProcess" to the debug server via command line in launch scenarios.

Fix debugpy.configure() being a no-op rather than a shim for api.configure().