### PR TITLE
Fix #99: multiprocessing triggers preLaunchTask and postDebugTask more than once

### DIFF
--- a/src/debugpy/adapter/clients.py
+++ b/src/debugpy/adapter/clients.py
@@ -305,7 +305,9 @@ class Client(components.Component):
             raise request.cant_handle('"sudo":true is not supported on Windows.')
 
         servers.serve()
-        launchers.spawn_debuggee(self.session, request, args, console, console_title, sudo)
+        launchers.spawn_debuggee(
+            self.session, request, args, console, console_title, sudo
+        )
 
     @_start_message_handler
     def attach_request(self, request):
@@ -499,8 +501,9 @@ class Client(components.Component):
             body = dict(self.start_request.arguments)
             self._known_subprocesses.add(conn)
 
-        body.pop("processId", None)
-        body.pop("listen", None)
+        for key in "processId", "listen", "preLaunchTask", "postDebugTask":
+            body.pop(key, None)
+
         body["name"] = fmt("Subprocess {0}", conn.pid)
         body["request"] = "attach"
         body["subProcessId"] = conn.pid

--- a/tests/debug/config.py
+++ b/tests/debug/config.py
@@ -39,6 +39,8 @@ class DebugConfig(collections.MutableMapping):
         "name": (),
         "noDebug": False,
         "pathMappings": [],
+        "postDebugTask": (),
+        "preLaunchTask": (),
         "pyramid": False,
         "pythonPath": (),
         "redirectOutput": False,

--- a/tests/debugpy/test_multiproc.py
+++ b/tests/debugpy/test_multiproc.py
@@ -15,6 +15,7 @@ from tests.patterns import some
 
 
 if not tests.full:
+
     @pytest.fixture(params=[runners.launch] + runners.all_attach_socket)
     def run(request):
         return request.param
@@ -120,10 +121,7 @@ def test_multiprocessing(pyfile, target, run, start_method):
                 "name": some.str,
                 "request": "attach",
                 "subProcessId": some.int,
-                "connect": {
-                    "host": some.str,
-                    "port": some.int,
-                }
+                "connect": {"host": some.str, "port": some.int},
             }
         )
 
@@ -142,10 +140,7 @@ def test_multiprocessing(pyfile, target, run, start_method):
                     "name": some.str,
                     "request": "attach",
                     "subProcessId": some.int,
-                    "connect": {
-                        "host": some.str,
-                        "port": some.int,
-                    }
+                    "connect": {"host": some.str, "port": some.int},
                 }
             )
 
@@ -196,6 +191,9 @@ def test_subprocess(pyfile, target, run, subProcess):
 
     with debug.Session() as parent_session:
         backchannel = parent_session.open_backchannel()
+
+        parent_session.config["preLaunchTask"] = "doSomething"
+        parent_session.config["postDebugTask"] = "doSomethingElse"
         if subProcess is not None:
             parent_session.config["subProcess"] = subProcess
 
@@ -203,16 +201,14 @@ def test_subprocess(pyfile, target, run, subProcess):
             pass
 
         expected_child_config = dict(parent_session.config)
-        expected_child_config.pop("listen", None)
+        for key in "processId", "listen", "preLaunchTask", "postDebugTask":
+            expected_child_config.pop(key, None)
         expected_child_config.update(
             {
                 "name": some.str,
                 "request": "attach",
                 "subProcessId": some.int,
-                "connect": {
-                    "host": some.str,
-                    "port": some.int,
-                }
+                "connect": {"host": some.str, "port": some.int},
             }
         )
 


### PR DESCRIPTION
Remove "preLaunchTask" and "postDebugTask" from derived debug configurations generated for subprocesses.