### PR TITLE
Fix #108: Debugger freezes in VSCode

### DIFF
--- a/src/debugpy/adapter/__main__.py
+++ b/src/debugpy/adapter/__main__.py
@@ -20,6 +20,12 @@ __file__ = os.path.abspath(__file__)
 
 
 def main(args):
+    # If we're talking DAP over stdio, stderr is not guaranteed to be read from,
+    # so disable it to avoid the pipe filling and locking up. This must be done
+    # as early as possible, before the logging module starts writing to it.
+    if args.port is None:
+        sys.stderr = open(os.devnull, "w")
+
     from debugpy import adapter
     from debugpy.common import compat, log, sockets
     from debugpy.adapter import clients, servers, sessions

--- a/src/debugpy/adapter/clients.py
+++ b/src/debugpy/adapter/clients.py
@@ -43,7 +43,6 @@ class Client(components.Component):
             # that are going to be used for DAP communication from now on.
             sys.stdin = open(os.devnull, "r")
             sys.stdout = open(os.devnull, "w")
-            sys.stderr = open(os.devnull, "w")
         else:
             stream = messaging.JsonIOStream.from_socket(sock)
 


### PR DESCRIPTION
When talking DAP over stdio, disable stderr before logging anything to it.