### PR TITLE
sourceReference should be 0 for Jupyter cells. Fixes #113

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -1223,7 +1223,7 @@ def build_exception_info_response(dbg, thread_id, request_seq, set_additional_th
                 exc_type = frames_list.exc_type
                 exc_desc = frames_list.exc_desc
                 trace_obj = frames_list.trace_obj
-                for frame_id, frame, method_name, original_filename, filename_in_utf8, lineno in iter_visible_frames_info(
+                for frame_id, frame, method_name, original_filename, filename_in_utf8, lineno, _applied_mapping in iter_visible_frames_info(
                         dbg, frames_list):
 
                     line_text = linecache.getline(original_filename, lineno)

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_xml.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_xml.py
@@ -172,9 +172,10 @@ class NetCommandFactory(object):
             lineno = frames_list.frame_id_to_lineno.get(frame_id, frame.f_lineno)
 
             filename_in_utf8, lineno, changed = py_db.source_mapping.map_to_client(abs_path_real_path_and_base[0], lineno)
-            filename_in_utf8 = pydevd_file_utils.norm_file_to_client(filename_in_utf8)
+            new_filename_in_utf8, applied_mapping = pydevd_file_utils.norm_file_to_client(filename_in_utf8)
+            applied_mapping = applied_mapping or changed
 
-            yield frame_id, frame, method_name, abs_path_real_path_and_base[0], filename_in_utf8, lineno
+            yield frame_id, frame, method_name, abs_path_real_path_and_base[0], new_filename_in_utf8, lineno, applied_mapping
 
     def make_thread_stack_str(self, py_db, frames_list):
         assert frames_list.__class__ == FramesList
@@ -183,7 +184,7 @@ class NetCommandFactory(object):
         append = cmd_text_list.append
 
         try:
-            for frame_id, frame, method_name, _original_filename, filename_in_utf8, lineno in self._iter_visible_frames_info(
+            for frame_id, frame, method_name, _original_filename, filename_in_utf8, lineno, _applied_mapping in self._iter_visible_frames_info(
                     py_db, frames_list
                 ):
 

--- a/src/debugpy/_vendored/pydevd/pydevd_concurrency_analyser/pydevd_concurrency_logger.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_concurrency_analyser/pydevd_concurrency_logger.py
@@ -52,10 +52,10 @@ def get_text_list_for_frame(frame):
 
             filename = pydevd_file_utils.get_abs_path_real_path_and_base_from_frame(curFrame)[1]
 
-            myFile = pydevd_file_utils.norm_file_to_client(filename)
+            my_file, _applied_mapping = pydevd_file_utils.norm_file_to_client(filename)
 
-            # print "file is ", myFile
-            # myFile = inspect.getsourcefile(curFrame) or inspect.getfile(frame)
+            # print "file is ", my_file
+            # my_file = inspect.getsourcefile(curFrame) or inspect.getfile(frame)
 
             myLine = str(curFrame.f_lineno)
             # print "line is ", myLine
@@ -65,7 +65,7 @@ def get_text_list_for_frame(frame):
 
             variables = ''
             cmdTextList.append('<frame id="%s" name="%s" ' % (myId , pydevd_xml.make_valid_xml_value(myName)))
-            cmdTextList.append('file="%s" line="%s">' % (quote(myFile, '/>_= \t'), myLine))
+            cmdTextList.append('file="%s" line="%s">' % (quote(my_file, '/>_= \t'), myLine))
             cmdTextList.append(variables)
             cmdTextList.append("</frame>")
             curFrame = curFrame.f_back

--- a/src/debugpy/_vendored/pydevd/pydevd_file_utils.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_file_utils.py
@@ -529,7 +529,7 @@ def _original_file_to_client(filename, cache={}):
         return cache[filename]
     except KeyError:
         translated = _path_to_expected_str(get_path_with_real_case(_AbsFile(filename)))
-        cache[filename] = translated
+        cache[filename] = (translated, False)
     return cache[filename]
 
 
@@ -726,7 +726,7 @@ def setup_client_server_paths(paths):
 
             # The resulting path is not in the python process, so, we cannot do a _NormFile here,
             # only at the beginning of this method.
-            cache[filename] = translated
+            cache[filename] = (translated, path_mapping_applied)
 
             if translated not in _client_filename_in_utf8_to_source_reference:
                 if path_mapping_applied:
@@ -736,7 +736,7 @@ def setup_client_server_paths(paths):
                 _client_filename_in_utf8_to_source_reference[translated] = source_reference
                 _source_reference_to_server_filename[source_reference] = filename
 
-            return translated
+            return (translated, path_mapping_applied)
 
     norm_file_to_server = _norm_file_to_server
     norm_file_to_client = _norm_file_to_client

--- a/src/debugpy/_vendored/pydevd/tests/test_pydevconsole.py
+++ b/src/debugpy/_vendored/pydevd/tests/test_pydevconsole.py
@@ -98,10 +98,10 @@ class Test(unittest.TestCase):
                 if c[0] == 'RuntimeError':
                     self.fail('Did not expect to find RuntimeError there')
 
-            self.assertTrue(('__doc__', None, '', '3') not in interpreter.getCompletions('foo.CO', 'foo.'))
+            assert ('__doc__', None, '', '3') not in interpreter.getCompletions('foo.CO', 'foo.')
 
             comps = interpreter.getCompletions('va', 'va')
-            self.assertTrue(('val', '', '', '3') in comps or ('val', '', '', '4') in comps)
+            assert ('val', '', '', '3') in comps or ('val', '', '', '4') in comps
 
             interpreter.add_exec(CodeFragment('s = "mystring"'))
 

--- a/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
@@ -749,11 +749,13 @@ class AbstractWriterThread(threading.Thread):
         dirname = os.path.dirname(dirname)
         return os.path.abspath(os.path.join(dirname, 'pydevconsole.py'))
 
-    def get_line_index_with_content(self, line_content):
+    def get_line_index_with_content(self, line_content, filename=None):
         '''
         :return the line index which has the given content (1-based).
         '''
-        with open(self.TEST_FILE, 'r') as stream:
+        if filename is None:
+            filename = self.TEST_FILE
+        with open(filename, 'r') as stream:
             for i_line, line in enumerate(stream):
                 if line_content in line:
                     return i_line + 1

--- a/src/debugpy/_vendored/pydevd/tests_python/resources/_debugger_case_linecache_existing_file.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/resources/_debugger_case_linecache_existing_file.py
@@ -1,0 +1,12 @@
+import linecache
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+import _debugger_case_stepping
+
+linecache.updatecache(_debugger_case_stepping.__file__)
+assert linecache.getline(_debugger_case_stepping.__file__, 1)
+_debugger_case_stepping.Call()
+
+print('TEST SUCEEDED')

--- a/src/debugpy/_vendored/pydevd/tests_python/resources/_debugger_case_source_mapping_and_reference.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/resources/_debugger_case_source_mapping_and_reference.py
@@ -1,0 +1,57 @@
+def full_function():
+    # Note that this function is not called, it's there just to make the mapping explicit.
+    a = 1  # map to cell1, line 2
+    b = 2  # map to cell1, line 3
+
+    c = 3  # map to cell2, line 2
+    d = 4  # map to cell2, line 3
+
+
+def create_code():
+    cell1_code = compile(''' # line 1
+a = 1  # line 2
+b = 2  # line 3
+''', '<cell1>', 'exec')
+
+    cell2_code = compile('''# line 1
+c = 3  # line 2
+d = 4  # line 3
+''', '<cell2>', 'exec')
+
+    # Set up the source in linecache. Python doesn't have a public API for
+    # this, so we have to hack around it, similar to what IPython does.
+    import linecache
+    import time
+    code = ''' # line 1
+a = 1  # line 2
+b = 2  # line 3
+'''
+    linecache.cache['<cell1>'] = (
+        len(code),
+        time.time(),
+        [line + '\n' for line in code.splitlines()],
+        '<cell1>',
+    )
+
+    code = '''# line 1
+c = 3  # line 2
+d = 4  # line 3
+'''
+    linecache.cache['<cell2>'] = (
+        len(code),
+        time.time(),
+        [line + '\n' for line in code.splitlines()],
+        '<cell2>',
+    )
+
+    return {'cell1': cell1_code, 'cell2': cell2_code}
+
+
+if __name__ == '__main__':
+    code = create_code()
+    exec(code['cell1'])
+    exec(code['cell1'])
+
+    exec(code['cell2'])
+    exec(code['cell2'])
+    print('TEST SUCEEDED')


### PR DESCRIPTION
This fixes the regression related to the `sourceReference` in Jupyter.

@karthiknadig I think this is a critical fix for Jupyter debugging (so, we may want to do a release after this is integrated).