### PR TITLE
Fix #156: Add a flag for the old way of handling args from a launch config

### DIFF
--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -67,14 +67,14 @@ def launch_request(request):
         debugpy_args = request("debugpyArgs", json.array(unicode))
         cmdline += debugpy_args
 
-    # Use command line arguments propagated via launcher CLI, rather than "args", to get
-    # their values after shell expansion in "runInTerminal" scenarios. The command line
-    # parser in __main__ has already removed everything up to and including "--" by now.
+    # Further arguments can come via two channels: the launcher's own command line, or
+    # "args" in the request; effective arguments are concatenation of these two in order.
+    # Arguments for debugpy (such as -m) always come via CLI, but those specified by the
+    # user via "args" are passed differently by the adapter depending on "argsExpansion".
     cmdline += sys.argv[1:]
+    cmdline += request("args", json.array(unicode))
 
-    # We want the process name to reflect the target. So for -m, use the module name
-    # that follows; otherwise use the first argument, which is either -c or filename.
-    process_name = compat.filename(sys.argv[1] if sys.argv[1] != "-m" else sys.argv[2])
+    process_name = request("processName", compat.filename(sys.executable))
 
     env = os.environ.copy()
     env_changes = request("env", json.object(unicode))

--- a/tests/debug/config.py
+++ b/tests/debug/config.py
@@ -52,6 +52,7 @@ class DebugConfig(collections.MutableMapping):
         "type": (),
         # Launch
         "args": [],
+        "argsExpansion": "shell",
         "code": (),
         "console": "internal",
         "cwd": (),

--- a/tests/debugpy/test_args.py
+++ b/tests/debugpy/test_args.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import pytest
 
+from debugpy.common import log
 from tests import debug
 from tests.debug import runners, targets
 from tests.patterns import some
@@ -35,7 +36,8 @@ def test_args(pyfile, target, run):
 
 @pytest.mark.parametrize("target", targets.all)
 @pytest.mark.parametrize("run", runners.all_launch)
-def test_shell_expansion(pyfile, target, run):
+@pytest.mark.parametrize("expansion", ["", "none", "shell"])
+def test_shell_expansion(pyfile, target, run, expansion):
     @pyfile
     def code_to_debug():
         import sys
@@ -46,9 +48,11 @@ def test_shell_expansion(pyfile, target, run):
         backchannel.send(sys.argv)
 
     def expand(args):
+        log.info("Before expansion: {0}", args)
         for i, arg in enumerate(args):
             if arg.startswith("$"):
                 args[i] = arg[1:]
+        log.info("After expansion: {0}", args)
 
     class Session(debug.Session):
         def run_in_terminal(self, args, cwd, env):
@@ -57,11 +61,15 @@ def test_shell_expansion(pyfile, target, run):
 
     args = ["0", "$1", "2"]
     with Session() as session:
+        if expansion:
+            session.config["argsExpansion"] = expansion
+
         backchannel = session.open_backchannel()
         with run(session, target(code_to_debug, args=args)):
             pass
+
         argv = backchannel.receive()
 
-    if session.config["console"] != "internalConsole":
+    if session.config["console"] != "internalConsole" and expansion != "none":
         expand(args)
     assert argv == [some.str] + args


### PR DESCRIPTION
Add new property "argsExpansion", which defaults to "shell", but can be explicitly set to "none" to request no expansion.

Propagate "args" to launcher via CLI or JSON, depending on the value of "argsExpansion".

Move the logic to compute process name back to the adapter, alongside other processing of "launch" targets.