### PR TITLE
Remote launch tweaks & fixes

### DIFF
--- a/src/debugpy/adapter/clients.py
+++ b/src/debugpy/adapter/clients.py
@@ -324,14 +324,14 @@ class Client(components.Component):
             raise request.cant_handle('"sudo":true is not supported on Windows.')
 
         launcher_path = request("debugLauncherPath", os.path.dirname(launcher.__file__))
-        launcher_host = request("debugLauncherHost", "127.0.0.1")
+        adapter_host = request("debugAdapterHost", "127.0.0.1")
 
-        servers.serve()
+        servers.serve(adapter_host)
         launchers.spawn_debuggee(
             self.session,
             request,
             launcher_path,
-            launcher_host,
+            adapter_host,
             args,
             cwd,
             console,

--- a/src/debugpy/adapter/launchers.py
+++ b/src/debugpy/adapter/launchers.py
@@ -68,6 +68,7 @@ class Launcher(components.Component):
 def spawn_debuggee(
     session,
     start_request,
+    python,
     launcher_path,
     adapter_host,
     args,
@@ -79,7 +80,8 @@ def spawn_debuggee(
     # -E tells sudo to propagate environment variables to the target process - this
     # is necessary for launcher to get DEBUGPY_LAUNCHER_PORT and DEBUGPY_LOG_DIR.
     cmdline = ["sudo", "-E"] if sudo else []
-    cmdline += [sys.executable, launcher_path]
+    cmdline += python
+    cmdline += [launcher_path]
     env = {}
 
     arguments = dict(start_request.arguments)

--- a/src/debugpy/adapter/launchers.py
+++ b/src/debugpy/adapter/launchers.py
@@ -69,7 +69,7 @@ def spawn_debuggee(
     session,
     start_request,
     launcher_path,
-    launcher_host,
+    adapter_host,
     args,
     cwd,
     console,
@@ -94,7 +94,7 @@ def spawn_debuggee(
 
     try:
         listener = sockets.serve(
-            "Launcher", on_launcher_connected, launcher_host, backlog=1
+            "Launcher", on_launcher_connected, adapter_host, backlog=1
         )
     except Exception as exc:
         raise start_request.cant_handle(

--- a/src/debugpy/launcher/__init__.py
+++ b/src/debugpy/launcher/__init__.py
@@ -12,19 +12,27 @@ import os
 __file__ = os.path.abspath(__file__)
 
 
+adapter_host = None
+"""The host on which adapter is running and listening for incoming connections
+from the launcher and the servers."""
+
 channel = None
 """DAP message channel to the adapter."""
 
 
 def connect(host, port):
-    from debugpy.common import messaging, sockets
+    from debugpy.common import log, messaging, sockets
     from debugpy.launcher import handlers
 
-    global channel
+    global channel, adapter_host
     assert channel is None
+    assert adapter_host is None
+
+    log.info("Connecting to adapter at {0}:{1}", host, port)
 
     sock = sockets.create_client()
     sock.connect((host, port))
+    adapter_host = host
 
     stream = messaging.JsonIOStream.from_socket(sock, "Adapter")
     channel = messaging.JsonMessageChannel(stream, handlers=handlers)

--- a/src/debugpy/launcher/__main__.py
+++ b/src/debugpy/launcher/__main__.py
@@ -33,9 +33,11 @@ def main():
 
     # Everything before "--" is command line arguments for the launcher itself,
     # and everything after "--" is command line arguments for the debuggee.
+    log.info("sys.argv before parsing: {0}", sys.argv)
     sep = sys.argv.index("--")
     launcher_argv = sys.argv[1:sep]
-    sys.argv = [sys.argv[0]] + sys.argv[sep + 1:]
+    sys.argv[:] = [sys.argv[0]] + sys.argv[sep + 1:]
+    log.info("sys.argv after patching: {0}", sys.argv)
 
     # The first argument specifies the host/port on which the adapter is waiting
     # for launcher to connect. It's either host:port, or just port.

--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -39,19 +39,8 @@ def launch_request(request):
 
         return value
 
-    # "pythonPath" is a deprecated legacy spelling. If "python" is missing, then try
-    # the alternative. But if both are missing, the error message should say "python".
-    python_key = "python"
-    if python_key in request:
-        if "pythonPath" in request:
-            raise request.isnt_valid(
-                '"pythonPath" is not valid if "python" is specified'
-            )
-    elif "pythonPath" in request:
-        python_key = "pythonPath"
-    cmdline = request(python_key, json.array(unicode, vectorize=True, size=(0,)))
-    if not len(cmdline):
-        cmdline = [compat.filename(sys.executable)]
+    python_args = request("pythonArgs", json.array(unicode, vectorize=True, size=(0,)))
+    cmdline = [compat.filename(sys.executable)] + python_args
 
     if not request("noDebug", json.default(False)):
         port = request("port", int)

--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -9,6 +9,7 @@ import os
 import sys
 
 import debugpy
+from debugpy import launcher
 from debugpy.common import compat, json
 from debugpy.common.compat import unicode
 from debugpy.launcher import debuggee
@@ -57,7 +58,7 @@ def launch_request(request):
         cmdline += [
             compat.filename(os.path.dirname(debugpy.__file__)),
             "--connect",
-            str(port),
+            launcher.adapter_host + ":" + str(port),
         ]
         if not request("subProcess", True):
             cmdline += ["--configure-subProcess", "False"]

--- a/tests/debug/runners.py
+++ b/tests/debug/runners.py
@@ -331,12 +331,9 @@ debugpy.connect({address!r})
 attach_listen.host = "127.0.0.1"
 attach_listen.port = net.get_test_server_port(5478, 5600)
 
+all_launch_terminal = [launch["integratedTerminal"], launch["externalTerminal"]]
 
-all_launch = [
-    launch["internalConsole"],
-    launch["integratedTerminal"],
-    launch["externalTerminal"],
-]
+all_launch = [launch["internalConsole"]] + all_launch_terminal
 
 all_attach_listen = [attach_listen["api"], attach_listen["cli"]]
 


### PR DESCRIPTION
Rename "debugLauncherHost" to "debugAdapterHost", to more accurately reflect its meaning.

Fix launcher to propagate "debugAdapterHost" to debug server.

Add more logging to launcher.