### PR TITLE
Fix #304: Breakpoints not working with QThread/PySide2

### DIFF
--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -49,8 +49,18 @@ def launch_request(request):
             "--connect",
             launcher.adapter_host + ":" + str(port),
         ]
+
         if not request("subProcess", True):
             cmdline += ["--configure-subProcess", "False"]
+
+        qt_mode = request(
+            "qt",
+            json.enum(
+                "auto", "none", "pyside", "pyside2", "pyqt4", "pyqt5", optional=True
+            ),
+        )
+        cmdline += ["--configure-qt", qt_mode]
+
         adapter_access_token = request("adapterAccessToken", unicode, optional=True)
         if adapter_access_token != ():
             cmdline += ["--adapter-access-token", compat.filename(adapter_access_token)]

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -50,7 +50,7 @@ class Options(object):
 
 
 options = Options()
-options.config = {"subProcess": True}
+options.config = {"qt": "auto", "subProcess": True}
 
 
 def in_range(parser, start, stop):


### PR DESCRIPTION
Expose pydevd.enable_qt_support() in debugpy.server via debugpy.configure(qt=...) and --configure-qt ...

Expose the same in debugpy.adapter via "qt" debug configuration property.

Default to "auto" for all of the above, and also provide "none" to disable Qt monkey-patching entirely.