### PR TITLE
Fix #239: Timed out waiting for debugger to spawn

### DIFF
--- a/src/debugpy/adapter/clients.py
+++ b/src/debugpy/adapter/clients.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 import debugpy
-from debugpy import adapter, launcher
+from debugpy import adapter, common, launcher
 from debugpy.common import compat, fmt, json, log, messaging, sockets
 from debugpy.common.compat import unicode
 from debugpy.adapter import components, servers, sessions
@@ -436,12 +436,12 @@ class Client(components.Component):
                     raise request.isnt_valid('"processId" must be parseable as int')
             debugpy_args = request("debugpyArgs", json.array(unicode))
             servers.inject(pid, debugpy_args)
-            timeout = 10
+            timeout = common.PROCESS_SPAWN_TIMEOUT
             pred = lambda conn: conn.pid == pid
         else:
             if sub_pid == ():
                 pred = lambda conn: True
-                timeout = 10 if listen == () else None
+                timeout = common.PROCESS_SPAWN_TIMEOUT if listen == () else None
             else:
                 pred = lambda conn: conn.pid == sub_pid
                 timeout = 0

--- a/src/debugpy/adapter/sessions.py
+++ b/src/debugpy/adapter/sessions.py
@@ -10,6 +10,7 @@ import signal
 import threading
 import time
 
+from debugpy import common
 from debugpy.common import fmt, log, util
 from debugpy.adapter import components, launchers, servers
 
@@ -197,7 +198,8 @@ class Session(util.Observable):
             if self.server:
                 log.info('{0} waiting for "exited" event...', self)
                 if not self.wait_for(
-                    lambda: self.launcher.exit_code is not None, timeout=5
+                    lambda: self.launcher.exit_code is not None,
+                    timeout=common.PROCESS_EXIT_TIMEOUT,
                 ):
                     log.warning('{0} timed out waiting for "exited" event.', self)
 

--- a/src/debugpy/common/__init__.py
+++ b/src/debugpy/common/__init__.py
@@ -4,5 +4,13 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
+
 
 __all__ = []
+
+# The lower time bound for assuming that the process hasn't spawned successfully.
+PROCESS_SPAWN_TIMEOUT = os.getenv("DEBUGPY_PROCESS_SPAWN_TIMEOUT", 15)
+
+# The lower time bound for assuming that the process hasn't exited gracefully.
+PROCESS_EXIT_TIMEOUT = os.getenv("DEBUGPY_PROCESS_EXIT_TIMEOUT", 5)


### PR DESCRIPTION
Make timeouts for process spawning and exiting configurable, and increase the default value for spawning.