### PR TITLE
Don't patch stdin on debugpy. Fixes #296

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_command_line_handling.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_command_line_handling.py
@@ -78,6 +78,7 @@ ACCEPTED_ARG_HANDLERS = [
     ArgHandlerBool('print-in-debugger-startup'),
     ArgHandlerBool('cmd-line'),
     ArgHandlerBool('module'),
+    ArgHandlerBool('skip-notify-stdin'),
 
     # The ones below should've been just one setting to specify the protocol, but for compatibility
     # reasons they're passed as a flag but are mutually exclusive.

--- a/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
@@ -477,6 +477,7 @@ class DebuggerRunner(object):
             args,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            stdin=subprocess.PIPE,
             cwd=writer.get_cwd() if writer is not None else '.',
             env=env,
         )

--- a/src/debugpy/_vendored/pydevd/tests_python/test_pydev_monkey.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_pydev_monkey.py
@@ -61,7 +61,7 @@ def test_monkey_patch_args_indc():
     original = SetupHolder.setup
 
     try:
-        SetupHolder.setup = {'client': '127.0.0.1', 'port': '0', 'ppid': os.getpid(), 'protocol-quoted-line': True}
+        SetupHolder.setup = {'client': '127.0.0.1', 'port': '0', 'ppid': os.getpid(), 'protocol-quoted-line': True, 'skip-notify-stdin': True}
         check = ['C:\\bin\\python.exe', '-u', '-c', 'connect("127.0.0.1")']
         debug_command = (
             "import sys; sys.path.insert(0, r\'%s\'); import pydevd; pydevd.PydevdCustomization.DEFAULT_PROTOCOL='quoted-line'; "
@@ -86,7 +86,7 @@ def test_monkey_patch_args_module():
     original = SetupHolder.setup
 
     try:
-        SetupHolder.setup = {'client': '127.0.0.1', 'port': '0', 'multiprocess': True}
+        SetupHolder.setup = {'client': '127.0.0.1', 'port': '0', 'multiprocess': True, 'skip-notify-stdin': True}
         check = ['C:\\bin\\python.exe', '-m', 'test']
         from _pydevd_bundle.pydevd_command_line_handling import get_pydevd_file
         assert pydev_monkey.patch_args(check) == [
@@ -100,6 +100,7 @@ def test_monkey_patch_args_module():
             '--client',
             '127.0.0.1',
             '--multiprocess',
+            '--skip-notify-stdin',
             '--protocol-quoted-line',
             '--file',
             'test',

--- a/src/debugpy/server/api.py
+++ b/src/debugpy/server/api.py
@@ -40,6 +40,8 @@ _adapter_process = None
 
 def _settrace(*args, **kwargs):
     log.debug("pydevd.settrace(*{0!r}, **{1!r})", args, kwargs)
+    # The stdin in notification is not acted upon in debugpy, so, disable it.
+    kwargs.setdefault('notify_stdin', False)
     try:
         return pydevd.settrace(*args, **kwargs)
     except Exception:

--- a/tests/debugpy/test_output.py
+++ b/tests/debugpy/test_output.py
@@ -122,6 +122,24 @@ def test_non_ascii_output(pyfile, target, run):
     )
 
 
+def test_stdin_not_patched(pyfile, target, run):
+    @pyfile
+    def code_to_debug():
+        import sys
+        import debuggee
+        from debuggee import backchannel
+
+        debuggee.setup()
+        backchannel.send(sys.stdin == sys.__stdin__)
+
+    with debug.Session() as session:
+        backchannel = session.open_backchannel()
+        with run(session, target(code_to_debug)):
+            pass
+        is_original_stdin = backchannel.receive()
+        assert is_original_stdin, 'Expected sys.stdin and sys.__stdin__ to be the same.'
+
+
 if sys.platform == "win32":
 
     @pytest.mark.parametrize("redirect_output", ["", "redirect_output"])


### PR DESCRIPTION
Instead of redirecting `sys.stdin` optionally based on the redirect output flag, I ended up never redirecting wen using `pydevd` from `debugpy` (right now it doesn't have any usage for vscode anyways and there aren't any plans to use it either).