### PR TITLE
Fix #305: Add "pythonArgs" config property for interpreter arguments

### DIFF
--- a/src/debugpy/adapter/clients.py
+++ b/src/debugpy/adapter/clients.py
@@ -302,6 +302,8 @@ class Client(components.Component):
         python = request(python_key, json.array(unicode, vectorize=True, size=(0,)))
         if not len(python):
             python = [compat.filename(sys.executable)]
+            
+        python += request("pythonArgs", json.array(unicode, size=(0,)))
         request.arguments["pythonArgs"] = python[1:]
 
         program = module = code = ()

--- a/tests/debug/config.py
+++ b/tests/debug/config.py
@@ -42,6 +42,8 @@ class DebugConfig(collections.MutableMapping):
         "postDebugTask": (),
         "preLaunchTask": (),
         "pyramid": False,
+        "python": (),
+        "pythonArgs": [],
         "pythonPath": (),
         "redirectOutput": False,
         "rules": [],

--- a/tests/debug/runners.py
+++ b/tests/debug/runners.py
@@ -117,23 +117,22 @@ def _runner(f):
 
 
 @_runner
-def launch(session, target, console="integratedTerminal", cwd=None):
-    assert console in ("internalConsole", "integratedTerminal", "externalTerminal")
+def launch(session, target, console=None, cwd=None):
+    assert console in (None, "internalConsole", "integratedTerminal", "externalTerminal")
 
     log.info("Launching {0} in {1} using {2!j}.", target, session, console)
 
     target.configure(session)
     config = session.config
     config.setdefaults(
-        {
-            "console": "externalTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "pythonPath": sys.executable,
-        }
+        {"console": "externalTerminal", "internalConsoleOptions": "neverOpen"}
     )
-    config["console"] = console
+    if console is not None:
+        config["console"] = console
     if cwd is not None:
         config["cwd"] = cwd
+    if "python" not in config and "pythonPath" not in config:
+        config["python"] = sys.executable
 
     env = (
         session.spawn_adapter.env


### PR DESCRIPTION
Expose "pythonArgs" to clients.

Make "python" usable in tests in lieu of "pythonPath", and make the runners use it.

Add tests for all combinations of "python"/"pythonPath" and "pythonArgs".