### PR TITLE
Fix #125: Stop Debugging in a "noDebug" session doesn't kill subprocesses

### DIFF
--- a/src/debugpy/adapter/launchers.py
+++ b/src/debugpy/adapter/launchers.py
@@ -172,9 +172,6 @@ def spawn_debuggee(
         except messaging.MessageHandlingError as exc:
             exc.propagate(start_request)
 
-        if session.no_debug:
-            return
-
         if not session.wait_for(
             lambda: session.launcher.pid is not None,
             timeout=common.PROCESS_SPAWN_TIMEOUT,
@@ -182,6 +179,9 @@ def spawn_debuggee(
             raise start_request.cant_handle(
                 'Timed out waiting for "process" event from launcher'
             )
+
+        if session.no_debug:
+            return
 
         # Wait for the first incoming connection regardless of the PID - it won't
         # necessarily match due to the use of stubs like py.exe or "conda run".

--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -64,6 +64,7 @@ def launch_request(request):
         adapter_access_token = request("adapterAccessToken", unicode, optional=True)
         if adapter_access_token != ():
             cmdline += ["--adapter-access-token", compat.filename(adapter_access_token)]
+            
         debugpy_args = request("debugpyArgs", json.array(unicode))
         cmdline += debugpy_args
 

--- a/src/debugpy/launcher/winapi.py
+++ b/src/debugpy/launcher/winapi.py
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import ctypes
+from ctypes.wintypes import BOOL, DWORD, HANDLE, LARGE_INTEGER, LPCSTR, UINT
+
+from debugpy.common import log
+
+
+JOBOBJECTCLASS = ctypes.c_int
+LPDWORD = ctypes.POINTER(DWORD)
+LPVOID = ctypes.c_void_p
+SIZE_T = ctypes.c_size_t
+ULONGLONG = ctypes.c_ulonglong
+
+
+class IO_COUNTERS(ctypes.Structure):
+    _fields_ = [
+        ("ReadOperationCount", ULONGLONG),
+        ("WriteOperationCount", ULONGLONG),
+        ("OtherOperationCount", ULONGLONG),
+        ("ReadTransferCount", ULONGLONG),
+        ("WriteTransferCount", ULONGLONG),
+        ("OtherTransferCount", ULONGLONG),
+    ]
+
+
+class JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("PerProcessUserTimeLimit", LARGE_INTEGER),
+        ("PerJobUserTimeLimit", LARGE_INTEGER),
+        ("LimitFlags", DWORD),
+        ("MinimumWorkingSetSize", SIZE_T),
+        ("MaximumWorkingSetSize", SIZE_T),
+        ("ActiveProcessLimit", DWORD),
+        ("Affinity", SIZE_T),
+        ("PriorityClass", DWORD),
+        ("SchedulingClass", DWORD),
+    ]
+
+
+class JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("BasicLimitInformation", JOBOBJECT_BASIC_LIMIT_INFORMATION),
+        ("IoInfo", IO_COUNTERS),
+        ("ProcessMemoryLimit", SIZE_T),
+        ("JobMemoryLimit", SIZE_T),
+        ("PeakProcessMemoryUsed", SIZE_T),
+        ("PeakJobMemoryUsed", SIZE_T),
+    ]
+
+
+JobObjectExtendedLimitInformation = JOBOBJECTCLASS(9)
+
+JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+
+PROCESS_TERMINATE = 0x0001
+PROCESS_SET_QUOTA = 0x0100
+
+
+def _errcheck(is_error_result=(lambda result: not result)):
+    def impl(result, func, args):
+        if is_error_result(result):
+            log.debug("{0} returned {1}", func.__name__, result)
+            raise ctypes.WinError()
+        else:
+            return result
+
+    return impl
+
+
+kernel32 = ctypes.windll.kernel32
+
+kernel32.AssignProcessToJobObject.errcheck = _errcheck()
+kernel32.AssignProcessToJobObject.restype = BOOL
+kernel32.AssignProcessToJobObject.argtypes = (HANDLE, HANDLE)
+
+kernel32.CreateJobObjectA.errcheck = _errcheck(lambda result: result == 0)
+kernel32.CreateJobObjectA.restype = HANDLE
+kernel32.CreateJobObjectA.argtypes = (LPVOID, LPCSTR)
+
+kernel32.OpenProcess.errcheck = _errcheck(lambda result: result == 0)
+kernel32.OpenProcess.restype = HANDLE
+kernel32.OpenProcess.argtypes = (DWORD, BOOL, DWORD)
+
+kernel32.QueryInformationJobObject.errcheck = _errcheck()
+kernel32.QueryInformationJobObject.restype = BOOL
+kernel32.QueryInformationJobObject.argtypes = (
+    HANDLE,
+    JOBOBJECTCLASS,
+    LPVOID,
+    DWORD,
+    LPDWORD,
+)
+
+kernel32.SetInformationJobObject.errcheck = _errcheck()
+kernel32.SetInformationJobObject.restype = BOOL
+kernel32.SetInformationJobObject.argtypes = (HANDLE, JOBOBJECTCLASS, LPVOID, DWORD)
+
+kernel32.TerminateJobObject.errcheck = _errcheck()
+kernel32.TerminateJobObject.restype = BOOL
+kernel32.TerminateJobObject.argtypes = (HANDLE, UINT)


### PR DESCRIPTION
On Windows, run the debuggee in a separate Win32 job, and terminate the job when launcher exits.

On POSIX, run the debuggee in a separate process group (PGID), and kill the entire group when launcher exits.

Improve process tree autokill tests to actually check whether the child process has exited.