### PR TITLE
Fix #370: Terminal Keyboard Inputs not being accepted

### DIFF
--- a/tests/debugpy/test_input.py
+++ b/tests/debugpy/test_input.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest
+
+from tests import debug
+from tests.debug import runners
+
+
+@pytest.mark.parametrize("run", runners.all)
+@pytest.mark.parametrize("redirect_output", ["", "redirect_output"])
+def test_stdin_not_patched(pyfile, target, run, redirect_output):
+    @pyfile
+    def code_to_debug():
+        import sys
+        import debuggee
+        from debuggee import backchannel
+
+        debuggee.setup()
+        backchannel.send(sys.stdin is sys.__stdin__)
+
+    with debug.Session() as session:
+        session.config["redirectOutput"] = bool(redirect_output)
+
+        backchannel = session.open_backchannel()
+        with run(session, target(code_to_debug)):
+            pass
+
+        is_original_stdin = backchannel.receive()
+        assert is_original_stdin, "Expected sys.stdin and sys.__stdin__ to be the same."
+
+
+@pytest.mark.parametrize("run", runners.all_launch_terminal + runners.all_attach)
+@pytest.mark.parametrize("redirect_output", ["", "redirect_output"])
+def test_input(pyfile, target, run, redirect_output):
+    @pyfile
+    def code_to_debug():
+        import debuggee
+        from debuggee import backchannel
+
+        try:
+            input = raw_input
+        except NameError:
+            pass
+
+        debuggee.setup()
+        backchannel.send(input())
+
+    with debug.Session() as session:
+        session.config["redirectOutput"] = bool(redirect_output)
+
+        backchannel = session.open_backchannel()
+        with run(session, target(code_to_debug)):
+            pass
+
+        session.debuggee.stdin.write(b"ok\n")
+        s = backchannel.receive()
+        assert s == "ok"

--- a/tests/debugpy/test_output.py
+++ b/tests/debugpy/test_output.py
@@ -122,24 +122,6 @@ def test_non_ascii_output(pyfile, target, run):
     )
 
 
-def test_stdin_not_patched(pyfile, target, run):
-    @pyfile
-    def code_to_debug():
-        import sys
-        import debuggee
-        from debuggee import backchannel
-
-        debuggee.setup()
-        backchannel.send(sys.stdin == sys.__stdin__)
-
-    with debug.Session() as session:
-        backchannel = session.open_backchannel()
-        with run(session, target(code_to_debug)):
-            pass
-        is_original_stdin = backchannel.receive()
-        assert is_original_stdin, 'Expected sys.stdin and sys.__stdin__ to be the same.'
-
-
 if sys.platform == "win32":
 
     @pytest.mark.parametrize("redirect_output", ["", "redirect_output"])

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,9 +3,11 @@
 # pytest>=5 does not support Python 2.7
 pytest<5
 
+# pytest-xdist>=2 does not support Python 2.7
+pytest-xdist<2
+
 pytest-cov
 pytest-timeout
-pytest-xdist
 tox
 
 ## Used by test helpers:


### PR DESCRIPTION
Make the debuggee process group the foreground group in its session.

Add a test for input(), and improve existing stdin test to cover more cases.