### PR TITLE
Fix #81: Subprocess always waits for client to attach

### DIFF
--- a/tests/debug/runners.py
+++ b/tests/debug/runners.py
@@ -261,9 +261,7 @@ if {wait!r}:
         pass
 
     session.spawn_debuggee(args, cwd=cwd, setup=debuggee_setup)
-    if wait:
-        session.wait_for_adapter_socket()
-
+    session.wait_for_adapter_socket()
     session.connect_to_adapter((host, port))
     return session.request_attach()
 

--- a/tests/debug/session.py
+++ b/tests/debug/session.py
@@ -9,7 +9,6 @@ import itertools
 import os
 import psutil
 import py
-import pytest
 import subprocess
 import sys
 import time
@@ -457,10 +456,6 @@ class Session(object):
         )
 
     def send_request(self, command, arguments=None, proceed=True):
-        if command == "attach":
-            if sys.version_info[:2] == (3, 6) and sys.platform == "darwin":
-                pytest.skip("https://github.com/microsoft/ptvsd/issues/1967")
-
         self.before_request(command, arguments)
 
         if self.timeline.is_frozen and proceed:

--- a/tests/debug/session.py
+++ b/tests/debug/session.py
@@ -143,6 +143,10 @@ class Session(object):
         )
         """The debug configuration for this session."""
 
+        self.before_connect = lambda address: None
+        """Invoked right before a socket connection to the adapter is established.
+        """
+
         self.before_request = lambda command, arguments: None
         """Invoked for every outgoing request in this session, allowing any final
         tweaks to the request before it is sent.
@@ -421,6 +425,7 @@ class Session(object):
     def connect_to_adapter(self, address):
         assert self.channel is None
 
+        self.before_connect(address)
         host, port = address
         log.info("Connecting to {0} at {1}:{2}", self.adapter_id, host, port)
         sock = sockets.create_client()


### PR DESCRIPTION
Unblock subprocesses for which no notification could be sent to the client.