### PR TITLE
Fix #330: Unable to debug pythonw apps on macOS

### DIFF
--- a/src/debugpy/adapter/clients.py
+++ b/src/debugpy/adapter/clients.py
@@ -317,6 +317,7 @@ class Client(components.Component):
 
         python += request("pythonArgs", json.array(unicode, size=(0,)))
         request.arguments["pythonArgs"] = python[1:]
+        request.arguments["python"] = python
 
         program = module = code = ()
         if "program" in request:

--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -39,8 +39,8 @@ def launch_request(request):
 
         return value
 
-    python_args = request("pythonArgs", json.array(unicode, vectorize=True, size=(0,)))
-    cmdline = [compat.filename(sys.executable)] + python_args
+    python = request("python", json.array(unicode, size=(1,)))
+    cmdline = list(python)
 
     if not request("noDebug", json.default(False)):
         port = request("port", int)

--- a/tests/debugpy/test_multiproc.py
+++ b/tests/debugpy/test_multiproc.py
@@ -26,6 +26,9 @@ def expected_subprocess_config(parent_session):
     config = dict(parent_session.config)
     for key in "args", "listen", "postDebugTask", "preLaunchTask", "processId":
         config.pop(key, None)
+    for key in "python", "pythonArgs", "pythonPath":
+        if key in config:
+            config[key] = some.thing
     config.update(
         {
             "name": some.str,


### PR DESCRIPTION
In the launcher, use "python" instead of sys.executable to spawn the debuggee.

Update test for "python" / "pythonPath" / "pythonArgs" to use a helper script to assert the use of a custom Python binary; and test -B instead of -v to minimize test log size and run time.