### PR TITLE
Add a setuptools entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,5 +134,10 @@ if __name__ == "__main__":
             "debugpy._vendored": list(iter_vendored_files()),
         },
         cmdclass=cmds,
+        entry_points={
+            "console_scripts": [
+                "debugpy = debugpy.__main__:cli.main"
+            ]
+        },
         **extras
     )

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,9 @@ if __name__ == "__main__":
         cmdclass=cmds,
         entry_points={
             "console_scripts": [
-                "debugpy = debugpy.__main__:cli.main"
+                "debugpy = debugpy.__main__:cli.main",
+                "debugpy-adapter = debugpy.adapter.__main__:cli.main",
+                "debugpy-launcher = debugpy.launcher.__main__:cli.main",
             ]
         },
         **extras

--- a/setup.py
+++ b/setup.py
@@ -137,8 +137,8 @@ if __name__ == "__main__":
         entry_points={
             "console_scripts": [
                 "debugpy = debugpy.__main__:cli.main",
-                "debugpy-adapter = debugpy.adapter.__main__:cli.main",
-                "debugpy-launcher = debugpy.launcher.__main__:cli.main",
+                "debugpy-adapter = debugpy.adapter.__main__:cli",
+                "debugpy-launcher = debugpy.launcher.__main__:cli",
             ]
         },
         **extras

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
         cmdclass=cmds,
         entry_points={
             "console_scripts": [
-                "debugpy = debugpy.__main__:cli.main",
+                "debugpy = debugpy.server.cli:main",
                 "debugpy-adapter = debugpy.adapter.__main__:cli",
                 "debugpy-launcher = debugpy.launcher.__main__:cli",
             ]

--- a/src/debugpy/__main__.py
+++ b/src/debugpy/__main__.py
@@ -43,8 +43,3 @@ if __name__ == "__main__":
     from debugpy.server import cli
 
     cli.main()
-else:
-    # Instead of hard-coding "debugpy = debugpy.server.cli:main" in setup.py, import it
-    # here. If the fully-qualified name of our `main()` function changes, we don't need
-    # to change it in setup.py, as long as we import it here as `cli.main()`.
-    from debugpy.server import cli

--- a/src/debugpy/__main__.py
+++ b/src/debugpy/__main__.py
@@ -43,3 +43,8 @@ if __name__ == "__main__":
     from debugpy.server import cli
 
     cli.main()
+else:
+    # Instead of hard-coding "debugpy = debugpy.server.cli:main" in setup.py, import it
+    # here. If the fully-qualified name of our `main()` function changes, we don't need
+    # to change it in setup.py, as long as we import it here as `cli.main()`.
+    from debugpy.server import cli

--- a/src/debugpy/adapter/__main__.py
+++ b/src/debugpy/adapter/__main__.py
@@ -188,6 +188,19 @@ def _parse_argv(argv):
     return args
 
 
+def cli():
+    # Apply OS-global and user-specific locale settings.
+    try:
+        locale.setlocale(locale.LC_ALL, "")
+    except Exception:
+        # On POSIX, locale is set via environment variables, and this can fail if
+        # those variables reference a non-existing locale. Ignore and continue using
+        # the default "C" locale if so.
+        pass
+
+    main(_parse_argv(sys.argv))
+
+
 if __name__ == "__main__":
     # debugpy can also be invoked directly rather than via -m. In this case, the first
     # entry on sys.path is the one added automatically by Python for the directory
@@ -216,13 +229,4 @@ if __name__ == "__main__":
         __import__("debugpy")
         del sys.path[0]
 
-    # Apply OS-global and user-specific locale settings.
-    try:
-        locale.setlocale(locale.LC_ALL, "")
-    except Exception:
-        # On POSIX, locale is set via environment variables, and this can fail if
-        # those variables reference a non-existing locale. Ignore and continue using
-        # the default "C" locale if so.
-        pass
-
-    main(_parse_argv(sys.argv))
+    cli()

--- a/src/debugpy/launcher/__main__.py
+++ b/src/debugpy/launcher/__main__.py
@@ -55,6 +55,19 @@ def main():
         sys.exit(debuggee.process.returncode)
 
 
+def cli():
+    # Apply OS-global and user-specific locale settings.
+    try:
+        locale.setlocale(locale.LC_ALL, "")
+    except Exception:
+        # On POSIX, locale is set via environment variables, and this can fail if
+        # those variables reference a non-existing locale. Ignore and continue using
+        # the default "C" locale if so.
+        pass
+
+    main()
+
+
 if __name__ == "__main__":
     # debugpy can also be invoked directly rather than via -m. In this case, the first
     # entry on sys.path is the one added automatically by Python for the directory
@@ -83,13 +96,4 @@ if __name__ == "__main__":
         __import__("debugpy")
         del sys.path[0]
 
-    # Apply OS-global and user-specific locale settings.
-    try:
-        locale.setlocale(locale.LC_ALL, "")
-    except Exception:
-        # On POSIX, locale is set via environment variables, and this can fail if
-        # those variables reference a non-existing locale. Ignore and continue using
-        # the default "C" locale if so.
-        pass
-
-    main()
+    cli()


### PR DESCRIPTION
Add a Setuptools entry point, so that Debugpy can be invoked from the command line as:

```bash
debugpy           # Equivalent to: python -m debugpy
debugpy-adapter   # Equivalent to: python -m debugpy.adapter
debugpy-launcher  # Equivalent to: python -m debugpy.launcher
```

The main purpose of this change is so that Debugpy can be installed with [Pipx](https://pipxproject.github.io/pipx/). This enables Debugpy to be easily installed into a self-contained environment, for use with arbitrary clients (such as [Nvim-DAP](https://github.com/mfussenegger/nvim-dap)). Then it can be conveniently invoked in "adapter" mode as `debugpy-adapter`.

It's also (in my opinion) easier and more user-friendly to type `debugpy` instead of `python -m debugpy` on the command line :)