### PR TITLE
Fix Linux CI

### DIFF
--- a/azure-pipelines/linux-coverage.yaml
+++ b/azure-pipelines/linux-coverage.yaml
@@ -8,9 +8,10 @@ jobs:
       pool:
           name: Azure Pipelines
           demands: java
-          vmImage: "ubuntu-18.04"
+          vmImage: "ubuntu-latest"
       steps:
           - script: |
+              sudo apt-get update
               sudo apt-get --yes install gdb
               sudo sysctl kernel.yama.ptrace_scope=0
             displayName: 'Install gdb'

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -5,7 +5,7 @@ jobs:
     - job: "Lint"
       timeoutInMinutes: 15
       displayName: "Lint"
-      pool: { vmImage: "ubuntu-18.04" }
+      pool: { vmImage: "ubuntu-latest" }
 
       variables:
           python.version: "3.8"
@@ -33,7 +33,7 @@ jobs:
     - job: "Test_Linux"
       timeoutInMinutes: 30
       displayName: "Tests - Linux"
-      pool: { vmImage: "ubuntu-18.04" }
+      pool: { vmImage: "ubuntu-latest" }
 
       strategy:
           matrix:
@@ -50,6 +50,7 @@ jobs:
 
       steps:
           - script: |
+                sudo apt-get update
                 sudo apt-get --yes install gdb
                 sudo sysctl kernel.yama.ptrace_scope=0
             displayName: "Setup gdb"


### PR DESCRIPTION
Use ubuntu-20.04 to run Linux tests.

Update apt packages before trying to install gdb.