### PR TITLE
Sync with pydevd

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_frame_eval/pydevd_frame_eval_main.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_frame_eval/pydevd_frame_eval_main.py
@@ -3,7 +3,7 @@ import os
 from _pydev_bundle import pydev_log
 from _pydevd_bundle.pydevd_trace_dispatch import USING_CYTHON
 from _pydevd_bundle.pydevd_constants import USE_CYTHON_FLAG, ENV_FALSE_LOWER_VALUES, \
-    ENV_TRUE_LOWER_VALUES, IS_PY36_OR_GREATER, SUPPORT_GEVENT
+    ENV_TRUE_LOWER_VALUES, IS_PY36_OR_GREATER, SUPPORT_GEVENT, IS_PYTHON_STACKLESS
 
 frame_eval_func = None
 stop_frame_eval = None
@@ -18,10 +18,12 @@ use_frame_eval = os.environ.get('PYDEVD_USE_FRAME_EVAL', '').lower()
 if use_frame_eval in ENV_FALSE_LOWER_VALUES or USE_CYTHON_FLAG in ENV_FALSE_LOWER_VALUES or not USING_CYTHON:
     pass
 
-elif SUPPORT_GEVENT:
+elif SUPPORT_GEVENT or IS_PYTHON_STACKLESS:
     pass
     # i.e gevent and frame eval mode don't get along very well.
     # https://github.com/microsoft/debugpy/issues/189
+    # Same problem with Stackless.
+    # https://github.com/stackless-dev/stackless/issues/240
 
 elif use_frame_eval in ENV_TRUE_LOWER_VALUES:
     # Fail if unable to use

--- a/src/debugpy/_vendored/pydevd/pydevd.py
+++ b/src/debugpy/_vendored/pydevd/pydevd.py
@@ -90,7 +90,7 @@ from _pydevd_bundle.pydevd_thread_lifecycle import suspend_all_threads, mark_thr
 if USE_CUSTOM_SYS_CURRENT_FRAMES_MAP:
     from _pydevd_bundle.pydevd_constants import constructed_tid_to_last_frame
 
-__version_info__ = (2, 1, 0)
+__version_info__ = (2, 4, 1)
 __version_info_str__ = []
 for v in __version_info__:
     __version_info_str__.append(str(v))


### PR DESCRIPTION
Bump the version to match the current pydevd version and apply a fix to disable frame eval mode with stackless.