### PR TITLE
Fix #628: Flask tests fail because werkzeug.server.shutdown is deprecated

### DIFF
--- a/tests/test_data/flask1/app.py
+++ b/tests/test_data/flask1/app.py
@@ -1,8 +1,10 @@
+import os
 from flask import Flask
 from flask import render_template
 
 
 app = Flask(__name__)
+exiting = False
 
 
 @app.route("/")
@@ -34,10 +36,11 @@ def bad_template():
 
 @app.route("/exit")
 def exit_app():
-    from flask import request
-
-    func = request.environ.get("werkzeug.server.shutdown")
-    if func is None:
-        raise RuntimeError("No shutdown")
-    func()
+    global exiting
+    exiting = True
     return "Done"
+
+@app.teardown_request
+def teardown(exception):
+    if exiting:
+        os._exit(0)


### PR DESCRIPTION
Use @app.teardown_request to exit asynchronously after serving the response.