### PR TITLE
Do not install tox into tox

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,7 +6,6 @@ pytest
 pytest-xdist
 pytest-cov
 pytest-timeout
-tox
 
 ## Used by test helpers:
 

--- a/tests/requirements27.txt
+++ b/tests/requirements27.txt
@@ -8,7 +8,6 @@ pytest-xdist<2
 
 pytest-cov
 pytest-timeout
-tox
 
 ## Used by test helpers:
 

--- a/tests/requirements35.txt
+++ b/tests/requirements35.txt
@@ -6,7 +6,6 @@ pytest
 pytest-xdist
 pytest-cov
 pytest-timeout
-tox
 
 ## Used by test helpers:
 


### PR DESCRIPTION
Having tox as a dependency in requirements files means that
it's also installed in all the tox environments.