### PR TITLE
When possible collect try..except information from source and not bytecode.

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_collect_bytecode_info.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_collect_bytecode_info.py
@@ -28,10 +28,12 @@ class TryExceptInfo(object):
         self.try_line = try_line
         self.ignore = ignore
         self.except_line = -1
-        self.except_bytecode_offset = -1
         self.except_end_line = -1
-        self.except_end_bytecode_offset = -1
         self.raise_lines_in_except = []
+
+        # Note: these may not be available if generated from source instead of bytecode.
+        self.except_bytecode_offset = -1
+        self.except_end_bytecode_offset = -1
 
     def is_line_in_try_block(self, line):
         return self.try_line <= line < self.except_line
@@ -538,6 +540,77 @@ if sys.version_info[:2] >= (3, 10):
                                     _get_line(op_offset_to_line, raise_instruction.offset, firstlineno, search=True))
 
         return try_except_info_lst
+
+import ast as ast_module
+
+
+class _Visitor(ast_module.NodeVisitor):
+
+    def __init__(self):
+        self.try_except_infos = []
+        self._stack = []
+        self._in_except_stack = []
+        self.max_line = -1
+
+    def generic_visit(self, node):
+        if hasattr(node, 'lineno'):
+            if node.lineno > self.max_line:
+                self.max_line = node.lineno
+        return ast_module.NodeVisitor.generic_visit(self, node)
+
+    def visit_Try(self, node):
+        info = TryExceptInfo(node.lineno, ignore=True)
+        self._stack.append(info)
+        self.generic_visit(node)
+        assert info is self._stack.pop()
+        if not info.ignore:
+            self.try_except_infos.insert(0, info)
+
+    if sys.version_info[0] < 3:
+        visit_TryExcept = visit_Try
+
+    def visit_ExceptHandler(self, node):
+        info = self._stack[-1]
+        info.ignore = False
+        if info.except_line == -1:
+            info.except_line = node.lineno
+        self._in_except_stack.append(info)
+        self.generic_visit(node)
+        if hasattr(node, 'end_lineno'):
+            info.except_end_line = node.end_lineno
+        else:
+            info.except_end_line = self.max_line
+        self._in_except_stack.pop()
+
+    if sys.version_info[0] >= 3:
+
+        def visit_Raise(self, node):
+            for info in self._in_except_stack:
+                    if node.exc is None:
+                        info.raise_lines_in_except.append(node.lineno)
+            self.generic_visit(node)
+
+    else:
+
+        def visit_Raise(self, node):
+            for info in self._in_except_stack:
+                    if node.type is None and node.tback is None:
+                        info.raise_lines_in_except.append(node.lineno)
+            self.generic_visit(node)
+
+
+def collect_try_except_info_from_source(filename):
+    with open(filename, 'rb') as stream:
+        contents = stream.read()
+    return collect_try_except_info_from_contents(contents, filename)
+
+
+def collect_try_except_info_from_contents(contents, filename='<unknown>'):
+    ast = ast_module.parse(contents, filename)
+    visitor = _Visitor()
+    visitor.visit(ast)
+    return visitor.try_except_infos
+
 
 RESTART_FROM_LOOKAHEAD = object()
 SEPARATOR = object()

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_cython.c
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_cython.c
@@ -6478,7 +6478,7 @@ static PyObject *__pyx_f_14_pydevd_bundle_13pydevd_cython_is_unhandled_exception
  * 
  *     else:
  *         try_except_infos = container_obj.try_except_infos             # <<<<<<<<<<<<<<
- *         if not try_except_infos:
+ *         if try_except_infos is None:
  *             container_obj.try_except_infos = try_except_infos = py_db.collect_try_except_info(frame.f_code)
  */
   /*else*/ {
@@ -6490,17 +6490,17 @@ static PyObject *__pyx_f_14_pydevd_bundle_13pydevd_cython_is_unhandled_exception
     /* "_pydevd_bundle/pydevd_cython.pyx":207
  *     else:
  *         try_except_infos = container_obj.try_except_infos
- *         if not try_except_infos:             # <<<<<<<<<<<<<<
+ *         if try_except_infos is None:             # <<<<<<<<<<<<<<
  *             container_obj.try_except_infos = try_except_infos = py_db.collect_try_except_info(frame.f_code)
  * 
  */
-    __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_v_try_except_infos); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 207, __pyx_L1_error)
-    __pyx_t_2 = ((!__pyx_t_3) != 0);
+    __pyx_t_3 = (__pyx_v_try_except_infos == Py_None);
+    __pyx_t_2 = (__pyx_t_3 != 0);
     if (__pyx_t_2) {
 
       /* "_pydevd_bundle/pydevd_cython.pyx":208
  *         try_except_infos = container_obj.try_except_infos
- *         if not try_except_infos:
+ *         if try_except_infos is None:
  *             container_obj.try_except_infos = try_except_infos = py_db.collect_try_except_info(frame.f_code)             # <<<<<<<<<<<<<<
  * 
  *         if not try_except_infos:
@@ -6533,7 +6533,7 @@ static PyObject *__pyx_f_14_pydevd_bundle_13pydevd_cython_is_unhandled_exception
       /* "_pydevd_bundle/pydevd_cython.pyx":207
  *     else:
  *         try_except_infos = container_obj.try_except_infos
- *         if not try_except_infos:             # <<<<<<<<<<<<<<
+ *         if try_except_infos is None:             # <<<<<<<<<<<<<<
  *             container_obj.try_except_infos = try_except_infos = py_db.collect_try_except_info(frame.f_code)
  * 
  */

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_cython.pyx
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_cython.pyx
@@ -204,7 +204,7 @@ cdef is_unhandled_exception(container_obj, py_db, frame, int last_raise_line, se
 
     else:
         try_except_infos = container_obj.try_except_infos
-        if not try_except_infos:
+        if try_except_infos is None:
             container_obj.try_except_infos = try_except_infos = py_db.collect_try_except_info(frame.f_code)
 
         if not try_except_infos:

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_frame.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_frame.py
@@ -71,7 +71,7 @@ def is_unhandled_exception(container_obj, py_db, frame, last_raise_line, raise_l
 
     else:
         try_except_infos = container_obj.try_except_infos
-        if not try_except_infos:
+        if try_except_infos is None:
             container_obj.try_except_infos = try_except_infos = py_db.collect_try_except_info(frame.f_code)
 
         if not try_except_infos:

--- a/src/debugpy/_vendored/pydevd/tests_python/test_collect_bytecode_info/test_collect_try_except_info.json
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_collect_bytecode_info/test_collect_try_except_info.json
@@ -26,9 +26,5 @@
     ],
     "_method_simple_raise_unmatched_except": [
         "{try:1 except 3 end block 4}"
-    ],
-    "_method_try_except": [
-        "{try:1 except 6 end block 9 raises: 5}",
-        "{try:2 except 4 end block 5 raises: 5}"
     ]
 }

--- a/src/debugpy/_vendored/pydevd/tests_python/test_debugger.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_debugger.py
@@ -4279,6 +4279,14 @@ def test_frame_eval_mode_corner_case_many(case_setup, break_name):
             hit = writer.wait_for_breakpoint_hit(line=line)
             writer.write_run_thread(hit.thread_id)
 
+            if break_name == 'break with':
+                if sys.version_info[:2] >= (3, 10):
+                    # On Python 3.10 it'll actually backtrack for the
+                    # with and thus will execute the line where the
+                    # 'with' statement was started again.
+                    hit = writer.wait_for_breakpoint_hit(line=line)
+                    writer.write_run_thread(hit.thread_id)
+
             writer.finished_ok = True
 
 


### PR DESCRIPTION
Since in Python 3.10 collecting the try..except info with bytecode wasn't always possible, this makes it so that it'll be collected from the ast when possible instead (which is much easier and should also work for any other version of Python -- it does have the issue that if the code `__file__` it can't be used, in which case it falls back to using the bytecode, even though it's not 100% correct for Python 3.10, hopefully this should be rare in practice).

With this what's now missing to complete Python 3.10 support is cython and the frame eval mode (and gevent as the gevent version we do support doesn't really run on 3.10 anymore).

