### PR TITLE
Update pydevd_process_net_command_json.py

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -395,13 +395,14 @@ class PyDevJsonCommandProcessor(object):
 
         self.api.set_show_return_values(py_db, self._options.show_return_value)
 
+        ignore_system_exit_codes = []
         if not self._options.break_system_exit_zero:
-            ignore_system_exit_codes = [0, None]
-            if self._options.django_debug:
-                ignore_system_exit_codes += [3]
-
-            self.api.set_ignore_system_exit_codes(py_db, ignore_system_exit_codes)
-
+            ignore_system_exit_codes += [0, None]
+        if self._options.django_debug or self._options.flask_debug:
+            ignore_system_exit_codes += [3]
+        if ignore_system_exit_codes != []:
+            self.api.set_ignore_system_exit_codes(py_db, ignore_system_exit_codes)       
+        
         auto_reload = args.get('autoReload', {})
         if not isinstance(auto_reload, dict):
             pydev_log.info('Expected autoReload to be a dict. Received: %s' % (auto_reload,))

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -394,15 +394,14 @@ class PyDevJsonCommandProcessor(object):
             py_db.enable_output_redirection(False, False)
 
         self.api.set_show_return_values(py_db, self._options.show_return_value)
-
-        ignore_system_exit_codes = []
+    
         if not self._options.break_system_exit_zero:
-            ignore_system_exit_codes += [0, None]
-        if self._options.django_debug or self._options.flask_debug:
-            ignore_system_exit_codes += [3]
-        if ignore_system_exit_codes != []:
-            self.api.set_ignore_system_exit_codes(py_db, ignore_system_exit_codes)       
-        
+            ignore_system_exit_codes = [0, None]
+            if self._options.django_debug or self._options.flask_debug:
+                ignore_system_exit_codes += [3]
+
+            self.api.set_ignore_system_exit_codes(py_db, ignore_system_exit_codes)
+
         auto_reload = args.get('autoReload', {})
         if not isinstance(auto_reload, dict):
             pydev_log.info('Expected autoReload to be a dict. Received: %s' % (auto_reload,))

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -394,7 +394,7 @@ class PyDevJsonCommandProcessor(object):
             py_db.enable_output_redirection(False, False)
 
         self.api.set_show_return_values(py_db, self._options.show_return_value)
-    
+
         if not self._options.break_system_exit_zero:
             ignore_system_exit_codes = [0, None]
             if self._options.django_debug or self._options.flask_debug:


### PR DESCRIPTION
- primarily, I changed the line `if self._options.django_debug:` to `if self._options.django_debug or self._options.flask_debug:`, so that if the debug option `"flask": true` is set, the debugger does not interrupt the program flow when the flask app is restarted due to a source file being changed. When a change in a source file is observed by the debugger, it causes a `SystemExit` exception with code `3`, and the reloader automatically restarts the flask app.
- the other restructuring I did was due to my interpretation that even if `self._options.break_system_exit_zero` is `true`, i.e. if the debugger interrupts the flow when the program exits with error code `0`, the debugger still should not interrupt if it reloads the flask app due to a detected change in a source file.