### PR TITLE
Python 3.10: support for cython and frame eval mode.

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_frame_eval/vendored/bytecode/__init__.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_frame_eval/vendored/bytecode/__init__.py
@@ -35,9 +35,9 @@ from _pydevd_frame_eval.vendored.bytecode.concrete import (
     _ConvertBytecodeToConcrete,
 )
 from _pydevd_frame_eval.vendored.bytecode.cfg import BasicBlock, ControlFlowGraph  # noqa
+import sys
 
-
-def dump_bytecode(bytecode, *, lineno=False):
+def dump_bytecode(bytecode, *, lineno=False, stream=sys.stdout):
     def format_line(index, line):
         nonlocal cur_lineno, prev_lineno
         if lineno:
@@ -87,7 +87,7 @@ def dump_bytecode(bytecode, *, lineno=False):
             else:
                 fields.append("% 3s    %s" % (offset, format_instr(instr)))
                 line = "".join(fields)
-            print(line)
+            print(line, file=stream)
 
             offset += instr.size
     elif isinstance(bytecode, Bytecode):
@@ -101,30 +101,30 @@ def dump_bytecode(bytecode, *, lineno=False):
                 label = labels[instr]
                 line = "%s:" % label
                 if index != 0:
-                    print()
+                    print(file=stream)
             else:
                 if instr.lineno is not None:
                     cur_lineno = instr.lineno
                 line = format_instr(instr, labels)
                 line = indent + format_line(index, line)
-            print(line)
-        print()
+            print(line, file=stream)
+        print(file=stream)
     elif isinstance(bytecode, ControlFlowGraph):
         labels = {}
         for block_index, block in enumerate(bytecode, 1):
             labels[id(block)] = "block%s" % block_index
 
         for block_index, block in enumerate(bytecode, 1):
-            print("%s:" % labels[id(block)])
+            print("%s:" % labels[id(block)], file=stream)
             prev_lineno = None
             for index, instr in enumerate(block):
                 if instr.lineno is not None:
                     cur_lineno = instr.lineno
                 line = format_instr(instr, labels)
                 line = indent + format_line(index, line)
-                print(line)
+                print(line, file=stream)
             if block.next_block is not None:
-                print(indent + "-> %s" % labels[id(block.next_block)])
-            print()
+                print(indent + "-> %s" % labels[id(block.next_block)], file=stream)
+            print(file=stream)
     else:
         raise TypeError("unknown bytecode class")

--- a/src/debugpy/_vendored/pydevd/build_tools/build.py
+++ b/src/debugpy/_vendored/pydevd/build_tools/build.py
@@ -104,13 +104,13 @@ def build():
         # set VS100COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\Tools
 
         env = os.environ.copy()
-        if sys.version_info[:2] in ((2, 6), (2, 7), (3, 5), (3, 6), (3, 7), (3, 8), (3, 9)):
+        if sys.version_info[:2] in ((2, 6), (2, 7), (3, 5), (3, 6), (3, 7), (3, 8), (3, 9), (3, 10)):
             import setuptools  # We have to import it first for the compiler to be found
             from distutils import msvc9compiler
 
             if sys.version_info[:2] in ((2, 6), (2, 7)):
                 vcvarsall = msvc9compiler.find_vcvarsall(9.0)
-            elif sys.version_info[:2] in ((3, 5), (3, 6), (3, 7), (3, 8), (3, 9)):
+            elif sys.version_info[:2] in ((3, 5), (3, 6), (3, 7), (3, 8), (3, 9), (3, 10)):
                 vcvarsall = msvc9compiler.find_vcvarsall(14.0)
             if vcvarsall is None or not os.path.exists(vcvarsall):
                 raise RuntimeError('Error finding vcvarsall.')

--- a/src/debugpy/_vendored/pydevd/tests_python/resources/_bytecode_constructs.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/resources/_bytecode_constructs.py
@@ -62,11 +62,36 @@ def method8():
 
 
 def method9():
+    # As a note, Python 3.10 is eager to optimize this case and it duplicates the _c = 20
+    # in a codepath where the exception is raised and another where it's not raised.
+    # The frame eval mode must modify the bytecode so that both paths have the
+    # programmatic breakpoint added!
     try:
         _a = 10
     except:
         _b = 10
     finally:_c = 20  # break finally 2
+
+
+def method9a():
+    # Same as method9, but with exception raised (but handled).
+    try:
+        raise AssertionError()
+    except:
+        _b = 10
+    finally:_c = 20  # break finally 3
+
+
+def method9b():
+    # Same as method9, but with exception raised (unhandled).
+    try:
+        try:
+            raise RuntimeError()
+        except AssertionError:
+            _b = 10
+        finally:_c = 20  # break finally 4
+    except:
+        pass
 
 
 def method10():
@@ -94,6 +119,8 @@ if __name__ == '__main__':
     method7()
     method8()
     method9()
+    method9a()
+    method9b()
     method10()
     method11()
     print('TEST SUCEEDED')

--- a/src/debugpy/_vendored/pydevd/tests_python/resources/_bytecode_overflow_example.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/resources/_bytecode_overflow_example.py
@@ -1,3 +1,9 @@
+def check_backtrack(x):  # line 1
+    if not (x == 'a'  # line 2
+        or x == 'c'):  # line 3
+        pass  # line 4
+
+
 import re
 import sys
 

--- a/src/debugpy/_vendored/pydevd/tests_python/test_bytecode_manipulation.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_bytecode_manipulation.py
@@ -158,6 +158,12 @@ def test_set_pydevd_break_01():
     check('_bytecode_overflow_example.py', _bytecode_overflow_example.Dummy.fun, method_kwargs={'text': 'ing'})
 
 
+def test_set_pydevd_break_01a():
+    from tests_python.resources import _bytecode_overflow_example
+
+    check('_bytecode_overflow_example.py', _bytecode_overflow_example.check_backtrack, method_kwargs={'x': 'f'})
+
+
 def test_set_pydevd_break_02():
     from tests_python.resources import _bytecode_many_names_example
 

--- a/src/debugpy/_vendored/pydevd/tests_python/test_debugger.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_debugger.py
@@ -4263,6 +4263,8 @@ def test_frame_eval_mode_corner_case_04(case_setup):
         'break finally 1',
         'break except 2',
         'break finally 2',
+        'break finally 3',
+        'break finally 4',
         'break in dict',
         'break else',
     ]

--- a/src/debugpy/_vendored/pydevd/tests_runfiles/test_runfiles.py
+++ b/src/debugpy/_vendored/pydevd/tests_runfiles/test_runfiles.py
@@ -1,6 +1,7 @@
 import os.path
 import sys
-from tests_python.test_debugger import IS_PY26
+
+IS_PY26 = sys.version_info[:2] == (2, 6)
 
 IS_JYTHON = sys.platform.find('java') != -1
 


### PR DESCRIPTION
As a note, with this all the pydevd tests are running in 3.10 (with cython and frame eval), although one new test is failing in 3.9, but when trying to use the same fix used in 3.10 in 3.9, another unrelated test is failing in the ci (but not locally for me), so, I'll probably still have to investigate that approach a bit more as there may be some other nuance I'm missing when dealing with those bytecode changes, although I may pause a bit to tackle some other issues before getting back to the particular issue.