### PR TITLE
Fix #677, #689

### DIFF
--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -63,10 +63,10 @@ jobs:
 
           - template: "templates/run_tests.yml"
 
-    - job: "Test_MacOS"
+    - job: "Test_MacOS_old"
       timeoutInMinutes: 30
-      displayName: "Tests - macOS"
-      pool: { vmImage: "macOS-11" }
+      displayName: "Tests - macOS (old Python versions)"
+      pool: { vmImage: "macOS-10.14" }
 
       strategy:
           matrix:
@@ -76,6 +76,27 @@ jobs:
                   python.version: "3.5"
               py36:
                   python.version: "3.6"
+
+      steps:
+          - script: |
+                ulimit -Sn 8192
+            displayName: "Increase file descriptor limit"
+
+          - template: "templates/use_python.yml"
+
+          - script: |
+                python -m ensurepip --user
+            displayName: "Bootstrap pip"
+
+          - template: "templates/run_tests.yml"
+
+    - job: "Test_MacOS"
+      timeoutInMinutes: 30
+      displayName: "Tests - macOS"
+      pool: { vmImage: "macOS-11" }
+
+      strategy:
+          matrix:
               py37:
                   python.version: "3.7"
               py38:

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -49,6 +49,8 @@ jobs:
                   python.version: "3.8"
               py39:
                   python.version: "3.9"
+              py310:
+                  python.version: "3.10"
 
       steps:
           - script: |
@@ -80,6 +82,8 @@ jobs:
                   python.version: "3.8"
               py39:
                   python.version: "3.9"
+              py310:
+                  python.version: "3.10"
 
       steps:
           - script: |
@@ -113,6 +117,8 @@ jobs:
                   python.version: "3.8"
               py39:
                   python.version: "3.9"
+              py310:
+                  python.version: "3.10"
               py27_32:
                   python.version: "2.7"
                   architecture: "x86"

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -65,7 +65,7 @@ jobs:
 
     - job: "Test_MacOS_old"
       timeoutInMinutes: 30
-      displayName: "Tests - macOS (old Python versions)"
+      displayName: "Tests - macOS"
       pool: { vmImage: "macOS-10.14" }
 
       strategy:

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -66,7 +66,7 @@ jobs:
     - job: "Test_MacOS"
       timeoutInMinutes: 30
       displayName: "Tests - macOS"
-      pool: { vmImage: "macOS-10.14" }
+      pool: { vmImage: "macOS-11" }
 
       strategy:
           matrix:

--- a/tests/debugpy/test_django.py
+++ b/tests/debugpy/test_django.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
-import sys
 
 from debugpy.common import compat
 from tests import code, debug, log, net, test_data

--- a/tests/debugpy/test_django.py
+++ b/tests/debugpy/test_django.py
@@ -12,10 +12,7 @@ from tests import code, debug, log, net, test_data
 from tests.debug import runners, targets
 from tests.patterns import some
 
-pytestmark = [
-    pytest.mark.timeout(60),
-    pytest.mark.skipif(sys.version_info >= (3, 10), reason="https://github.com/microsoft/debugpy/issues/689"),
-]
+pytestmark = pytest.mark.timeout(60)
 
 django_server = net.WebServer(net.get_test_server_port(8000, 8100))
 


### PR DESCRIPTION
Fix #677: Enable CI for python 3.10
Fix #689: test_django fails on py3.10

Re-enable Django tests on Python 3.10, and add it to CI runs.