### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ To test integration between debugpy and Visual Studio Code, the latter can be di
 ```json5
 {
     "type": "python",
-    "debugAdapterPath": ".../debugpy/src/debugpy",
+    "debugAdapterPath": ".../debugpy/src/debugpy/adapter",
     ...
 }
 ```


### PR DESCRIPTION
The `debugAdapterPath` option should be set to `debugpy/src/debugpy/adapter`