### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,9 @@ if __name__ == "__main__":
         author="Microsoft Corporation",
         author_email="ptvshelp@microsoft.com",
         url="https://aka.ms/debugpy",
+        project_urls={
+            "Source": "https://github.com/microsoft/debugpy",
+        },
         python_requires=">=3.6",
         classifiers=[
             "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.