### PR TITLE
Corrected versioneer install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-debugpy/_version.py export-subst
+src/debugpy/_version.py export-subst


### PR DESCRIPTION
I tried using `git archive` and extracting the archive and running `python setup.py sdist`, but I got version `0+unknown`. This fixes that.