### PR TITLE
Re-enable frame eval mode by default.

### DIFF
--- a/src/debugpy/_vendored/force_pydevd.py
+++ b/src/debugpy/_vendored/force_pydevd.py
@@ -19,17 +19,10 @@ if _unvendored:
     # raise ImportError(msg)
     warnings.warn(msg + ':\n {}'.format('\n  '.join(_unvendored)))
 
-
 # If debugpy logging is enabled, enable it for pydevd as well
 if "DEBUGPY_LOG_DIR" in os.environ:
     os.environ[str("PYDEVD_DEBUG")] = str("True")
     os.environ[str("PYDEVD_DEBUG_FILE")] = os.environ["DEBUGPY_LOG_DIR"] + str("/debugpy.pydevd.log")
-
-# Work around https://github.com/microsoft/debugpy/issues/346.
-# Disable pydevd frame-eval optimizations only if unset, to allow opt-in.
-if "PYDEVD_USE_FRAME_EVAL" not in os.environ:
-    os.environ[str("PYDEVD_USE_FRAME_EVAL")] = str("NO")
-
 
 # Constants must be set before importing any other pydevd module
 # # due to heavy use of "from" in them.
@@ -55,7 +48,7 @@ preimport('pydevd', [
 # When pydevd is imported it sets the breakpoint behavior, but it needs to be
 # overridden because by default pydevd will connect to the remote debugger using
 # its own custom protocol rather than DAP.
-import pydevd   # noqa
+import pydevd  # noqa
 import debugpy  # noqa
 
 

--- a/tests/debugpy/test_run.py
+++ b/tests/debugpy/test_run.py
@@ -327,7 +327,7 @@ def test_frame_eval(pyfile, target, run, frame_eval):
             pass
 
         using_frame_eval = backchannel.receive()
-        assert using_frame_eval == (frame_eval == "yes")
+        assert using_frame_eval == (frame_eval in ("yes", ""))
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
It was disabled as temporary workaround in https://github.com/microsoft/debugpy/issues/346, but that was fixed and it appears it wasn't re-enabled...