### PR TITLE
Allow using pydevd as a regular dependency.

### DIFF
--- a/src/debugpy/__init__.py
+++ b/src/debugpy/__init__.py
@@ -206,6 +206,8 @@ def trace_this_thread(should_trace):
 
 __version__ = _version.get_versions()["version"]
 
+__bundling_disabled__ = False
+
 # Force absolute path on Python 2.
 __file__ = os.path.abspath(__file__)
 

--- a/src/debugpy/server/__init__.py
+++ b/src/debugpy/server/__init__.py
@@ -4,6 +4,50 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from importlib import import_module
+import os
+
 # "force_pydevd" must be imported first to ensure (via side effects)
 # that the debugpy-vendored copy of pydevd gets used.
-import debugpy._vendored.force_pydevd  # noqa
+import debugpy
+if debugpy.__bundling_disabled__:
+    # Do what force_pydevd.py does, but using the system-provided
+    # pydevd.
+
+    # XXX: This is copied here so that the whole '_vendored' directory
+    # can be deleted when DEBUGPY_BUNDLING_DISABLED is set.
+
+    # If debugpy logging is enabled, enable it for pydevd as well
+    if "DEBUGPY_LOG_DIR" in os.environ:
+        os.environ[str("PYDEVD_DEBUG")] = str("True")
+        os.environ[str("PYDEVD_DEBUG_FILE")] = \
+            os.environ["DEBUGPY_LOG_DIR"] + str("/debugpy.pydevd.log")
+
+    # Work around https://github.com/microsoft/debugpy/issues/346.
+    # Disable pydevd frame-eval optimizations only if unset, to allow opt-in.
+    if "PYDEVD_USE_FRAME_EVAL" not in os.environ:
+        os.environ[str("PYDEVD_USE_FRAME_EVAL")] = str("NO")
+
+    # Constants must be set before importing any other pydevd module
+    # due to heavy use of "from" in them.
+    pydevd_constants = import_module('_pydevd_bundle.pydevd_constants')
+    # The default pydevd value is 1000.
+    pydevd_constants.MAXIMUM_VARIABLE_REPRESENTATION_SIZE = 2 ** 32
+
+    # When pydevd is imported it sets the breakpoint behavior, but it needs to be
+    # overridden because by default pydevd will connect to the remote debugger using
+    # its own custom protocol rather than DAP.
+    import pydevd   # noqa
+    import debugpy  # noqa
+
+    def debugpy_breakpointhook():
+        debugpy.breakpoint()
+
+    pydevd.install_breakpointhook(debugpy_breakpointhook)
+
+    # Ensure that pydevd uses JSON protocol
+    from _pydevd_bundle import pydevd_constants
+    from _pydevd_bundle import pydevd_defaults
+    pydevd_defaults.PydevdCustomization.DEFAULT_PROTOCOL = pydevd_constants.HTTP_JSON_PROTOCOL
+else:
+    import debugpy._vendored.force_pydevd  # noqa

--- a/tests/tests/test_vendoring.py
+++ b/tests/tests/test_vendoring.py
@@ -1,3 +1,8 @@
+import pytest
+
+import debugpy
+
+@pytest.mark.skipif(debugpy.__bundling_disabled__, reason='Bundling disabled')
 def test_vendoring(pyfile):
     @pyfile
     def import_debugpy():


### PR DESCRIPTION
This makes it easier to test using PyDev-Debugger (pydevd) as a
standalone dependency rather than as a bundled (current status) one,
which comes with binaries checked in Git.

* setup.py (DEBUGPY_BUNDLING_DISABLED): New variable.
[DEBUGPY_BUNDLING_DISABLED]: Conditionalize 'debugpy._vendored'
import.
(PYDEVD_ROOT): Set only when DEBUGPY_BUNDLING_DISABLED is False.
(ExtModules.__bool__): Make the return value the negation of
DEBUGPY_BUNDLING_DISABLED.
(__main__)[DEBUGPY_BUNDLING_DISABLED]: New condition to call
'cython_build'.  Etch a __bundling_disabled__ variable on the debugpy
module.
<setuptools.setup>: Do not include the _vendored submodule in the
packages and package_data when DEBUGPY_BUNDLING_DISABLED is set.
Adjust has_ext_modules argument.
* src/debugpy/__init__.py: New '__bundling_disabled__' variable.
* src/debugpy/server/__init__.py [debugpy.__bundling_disabled__]:
Conditionalize 'debugpy._vendored.force_pydevd' import.
* src/debugpy/server/attach_pid_injected.py (attach): Import the
attach_script procedure from sys.path directly when
debugpy.__bundling_disabled__ is true and do not do any sys.path
manipulation in this case.
* tests/tests/test_vendoring.py: Skip test if
'debugpy.__bundling_disabled__' is true.
* src/debugpy/server/__init__.py: Partially copy the pydevd loading
logic from src/debugpy/_vendored/force_pydevd.py.