### PR TITLE
Fix typo in README example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following command injects the debugger into a process with a given PID that 
 ### Ignoring subprocesses
 The following command will ignore subprocesses started by the debugged process.
 ```console
--m debugpy --listen localhost:5678 --pid 12345 --config-subProcess False
+-m debugpy --listen localhost:5678 --pid 12345 --configure-subProcess False
 ```
 
 


### PR DESCRIPTION
I noticed that this example in the README does not seem to match the actual CLI usage (in source code, docs, and wiki). Figured I would just open a PR directly instead of an issue, as this seems like a straightforward edit 😀