### PR TITLE
Make errors with conditional breakpoints clearer. Fixes #893

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
@@ -129,7 +129,8 @@ class PyDevdAPI(object):
         py_db._gui_event_loop = gui_event_loop
 
     def send_error_message(self, py_db, msg):
-        sys.stderr.write('pydevd: %s\n' % (msg,))
+        cmd = py_db.cmd_factory.make_warning_message('pydevd: %s\n' % (msg,))
+        py_db.writer.add_command(cmd)
 
     def set_show_return_values(self, py_db, show_return_values):
         if show_return_values:

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -15,7 +15,7 @@ from _pydevd_bundle._debug_adapter.pydevd_schema import (
     ProcessEvent, Scope, ScopesResponseBody, SetExpressionResponseBody,
     SetVariableResponseBody, SourceBreakpoint, SourceResponseBody,
     VariablesResponseBody, SetBreakpointsResponseBody, Response,
-    Capabilities, PydevdAuthorizeRequest, Request, StepInTargetsResponse, StepInTarget,
+    Capabilities, PydevdAuthorizeRequest, Request,
     StepInTargetsResponseBody, SetFunctionBreakpointsResponseBody, BreakpointEvent,
     BreakpointEventBody)
 from _pydevd_bundle.pydevd_api import PyDevdAPI
@@ -35,7 +35,6 @@ from _pydevd_frame_eval.pydevd_frame_eval_main import USING_FRAME_EVAL
 from _pydevd_bundle.pydevd_comm import internal_get_step_in_targets_json
 from _pydevd_bundle.pydevd_additional_thread_info import set_additional_thread_info
 from _pydevd_bundle.pydevd_thread_lifecycle import pydevd_find_thread_by_id
-from _pydev_bundle._pydev_filesystem_encoding import getfilesystemencoding
 
 
 def _convert_rules_to_exclude_filters(rules, on_error):

--- a/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
@@ -199,6 +199,7 @@ class ReaderThread(threading.Thread):
         self._queue = Queue()
         self._kill = False
         self.accept_xml_messages = True
+        self.on_message_found = lambda msg: None
 
     def set_messages_timeout(self, timeout):
         self.MESSAGES_TIMEOUT = timeout
@@ -208,6 +209,7 @@ class ReaderThread(threading.Thread):
             timeout = self.MESSAGES_TIMEOUT
         try:
             msg = self._queue.get(block=True, timeout=timeout)
+            self.on_message_found(msg)
         except:
             raise TimeoutError('No message was written in %s seconds. Error message:\n%s' % (timeout, context_message,))
         else:

--- a/src/debugpy/_vendored/pydevd/tests_python/test_debugger_json.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_debugger_json.py
@@ -616,6 +616,33 @@ def test_case_json_hit_count_and_step(case_setup):
         writer.finished_ok = True
 
 
+def test_case_json_hit_condition_error(case_setup):
+    with case_setup.test_file('_debugger_case_hit_count.py') as writer:
+        json_facade = JsonFacade(writer)
+
+        json_facade.write_launch()
+        bp = writer.get_line_index_with_content('before loop line')
+        json_facade.write_set_breakpoints(
+            [bp],
+            line_to_info={
+                bp: {'condition': 'range.range.range'}
+        })
+        json_facade.write_make_initial_run()
+
+        def accept_message(msg):
+            if msg.body.category == 'important':
+                if 'Error while evaluating expression in conditional breakpoint' in msg.body.output:
+                    return True
+            return False
+
+        json_facade.wait_for_json_message(OutputEvent, accept_message=accept_message)
+
+        json_facade.wait_for_thread_stopped(line=bp)
+        json_facade.write_continue()
+
+        writer.finished_ok = True
+
+
 def test_case_process_event(case_setup):
     with case_setup.test_file('_debugger_case_change_breaks.py') as writer:
         json_facade = JsonFacade(writer)


### PR DESCRIPTION
Note that the error is no longer printed to stderr. Rather it's sent as an `important` output message.