### PR TITLE
add automatic conversion from string to int/float type

### DIFF
--- a/src/debugpy/common/json.py
+++ b/src/debugpy/common/json.py
@@ -93,6 +93,16 @@ class JsonObject(object):
 # some substitutions - e.g. replacing () with some default value.
 
 
+def _converter(value, classinfo):
+    """Convert value (str) to number, otherwise return None if is not possible"""
+    for one_info in classinfo:
+        if issubclass(one_info, numbers.Number):
+            try:
+                return one_info(value)
+            except ValueError:
+                pass
+
+
 def of_type(*classinfo, **kwargs):
     """Returns a validator for a JSON property that requires it to have a value of
     the specified type. If optional=True, () is also allowed.
@@ -108,12 +118,9 @@ def of_type(*classinfo, **kwargs):
         if (optional and value == ()) or isinstance(value, classinfo):
             return value
         else:
-            for one_info in classinfo:
-                if issubclass(one_info, numbers.Number):
-                    try:
-                        return one_info(value)
-                    except ValueError:
-                        pass
+            converted_value = _converter(value, classinfo)
+            if converted_value:
+                return converted_value
 
             if not optional and value == ():
                 raise ValueError("must be specified")

--- a/src/debugpy/common/json.py
+++ b/src/debugpy/common/json.py
@@ -108,7 +108,11 @@ def of_type(*classinfo, **kwargs):
     def validate(value):
         if (optional and value == ()) or isinstance(value, classinfo):
             return value
-        elif isinstance(value, str) and all(x in string.digits + '.' for x in value) and any(issubclass(x, numbers.Number) for x in classinfo):
+        elif (
+            isinstance(value, str)
+            and all(x in string.digits + "." for x in value)
+            and any(issubclass(x, numbers.Number) for x in classinfo)
+        ):
             try:
                 return int(value)
             except ValueError:

--- a/src/debugpy/common/json.py
+++ b/src/debugpy/common/json.py
@@ -7,9 +7,8 @@
 
 import builtins
 import json
-import operator
-import string
 import numbers
+import operator
 
 
 JsonDecoder = json.JSONDecoder
@@ -108,16 +107,14 @@ def of_type(*classinfo, **kwargs):
     def validate(value):
         if (optional and value == ()) or isinstance(value, classinfo):
             return value
-        elif (
-            isinstance(value, str)
-            and all(x in string.digits + "." for x in value)
-            and any(issubclass(x, numbers.Number) for x in classinfo)
-        ):
-            try:
-                return int(value)
-            except ValueError:
-                return float(value)
         else:
+            for one_info in classinfo:
+                if issubclass(one_info, numbers.Number):
+                    try:
+                        return one_info(value)
+                    except ValueError:
+                        pass
+
             if not optional and value == ():
                 raise ValueError("must be specified")
             raise TypeError("must be " + " or ".join(t.__name__ for t in classinfo))

--- a/src/debugpy/common/json.py
+++ b/src/debugpy/common/json.py
@@ -8,6 +8,8 @@
 import builtins
 import json
 import operator
+import string
+import numbers
 
 
 JsonDecoder = json.JSONDecoder
@@ -106,6 +108,11 @@ def of_type(*classinfo, **kwargs):
     def validate(value):
         if (optional and value == ()) or isinstance(value, classinfo):
             return value
+        elif isinstance(value, str) and all(x in string.digits + '.' for x in value) and any(issubclass(x, numbers.Number) for x in classinfo):
+            try:
+                return int(value)
+            except ValueError:
+                return float(value)
         else:
             if not optional and value == ():
                 raise ValueError("must be specified")

--- a/tests/debugpy/common/test_messaging.py
+++ b/tests/debugpy/common/test_messaging.py
@@ -659,13 +659,14 @@ class TestJsonMessageChannel(object):
 
 
 class TestTypeConversion(object):
-
     def test_str_to_num(self):
 
         # test conversion that are expected to work
         correct_trials = [("1.0", float), ("1", int), ("1", bool)]
         for val_trial, type_trial in correct_trials:
-            assert isinstance(json.of_type(type_trial)(val_trial), type_trial), f"Wrong type coversion"
+            assert isinstance(
+                json.of_type(type_trial)(val_trial), type_trial
+            ), f"Wrong type coversion"
 
         # test conversion that are not expected to work
         try:

--- a/tests/debugpy/common/test_messaging.py
+++ b/tests/debugpy/common/test_messaging.py
@@ -656,3 +656,20 @@ class TestJsonMessageChannel(object):
         assert fuzzer2.sent == fuzzer1.received
         assert fuzzer1.responses_sent == fuzzer2.responses_received
         assert fuzzer2.responses_sent == fuzzer1.responses_received
+
+
+class TestTypeConversion(object):
+
+    def test_str_to_num(self):
+
+        # test conversion that are expected to work
+        correct_trials = [("1.0", float), ("1", int), ("1", bool)]
+        for val_trial, type_trial in correct_trials:
+            assert isinstance(json.of_type(type_trial)(val_trial), type_trial), f"Wrong type coversion"
+
+        # test conversion that are not expected to work
+        try:
+            json.of_type(int)("1.0")
+            raise ValueError("This test should have failed")
+        except TypeError:
+            pass

--- a/tests/debugpy/common/test_messaging.py
+++ b/tests/debugpy/common/test_messaging.py
@@ -666,7 +666,7 @@ class TestTypeConversion(object):
         for val_trial, type_trial in correct_trials:
             assert isinstance(
                 json.of_type(type_trial)(val_trial), type_trial
-            ), f"Wrong type coversion"
+            ), "Wrong type coversion"
 
         # test conversion that are not expected to work
         try:


### PR DESCRIPTION
Relates to https://github.com/microsoft/vscode-python/issues/18841

Allow passing strings to the debugger for number-like inputs. With this fix strings will be accepted and automatically converted to int/float.