### PR TITLE
Fix TypeError in NetCommandFactoryJson.make_get_thread_stack_message()

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py
@@ -280,7 +280,7 @@ class NetCommandFactoryJson(NetCommandFactory):
         total_frames = len(frames)
         stack_frames = frames
         if bool(levels):
-            start = start_frame if bool(start_frame) else 0
+            start = start_frame
             end = min(start + levels, total_frames)
             stack_frames = frames[start:end]
 

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py
@@ -280,7 +280,7 @@ class NetCommandFactoryJson(NetCommandFactory):
         total_frames = len(frames)
         stack_frames = frames
         if bool(levels):
-            start = start_frame
+            start = start_frame if bool(start_frame) else 0
             end = min(start + levels, total_frames)
             stack_frames = frames[start:end]
 

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -944,8 +944,16 @@ class PyDevJsonCommandProcessor(object):
         # : :type stack_trace_arguments: StackTraceArguments
         stack_trace_arguments = request.arguments
         thread_id = stack_trace_arguments.threadId
-        start_frame = stack_trace_arguments.startFrame
-        levels = stack_trace_arguments.levels
+
+        if stack_trace_arguments.startFrame:
+            start_frame = int(stack_trace_arguments.startFrame)
+        else:
+            start_frame = 0
+
+        if stack_trace_arguments.levels:
+            levels = int(stack_trace_arguments.levels)
+        else:
+            levels = 0
 
         fmt = stack_trace_arguments.format
         if hasattr(fmt, 'to_dict'):


### PR DESCRIPTION
Dear maintainers, 

I experienced the following error using `debugpy` with Python3 in Version 3.9.2 both on macOS 12.3.1 and Debian Bookworm. 
The issue came up when using Emacs' `dap-mode`. 
```
Traceback (most recent call last):
  File "/home/username/.local/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py", line 252, in _on_run
    self.process_net_command_json(self.py_db, json_contents)
  File "/home/username/.local/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py", line 193, in process_net_command_json
    cmd = on_request(py_db, request)
  File "/home/username/.local/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py", line 953, in on_stacktrace_request
    self.api.request_stack(py_db, request.seq, thread_id, fmt=fmt, start_frame=start_frame, levels=levels)
  File "/home/username/.local/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_api.py", line 206, in request_stack
    if internal_get_thread_stack.can_be_executed_by(get_current_thread_id(threading.current_thread())):
  File "/home/username/.local/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py", line 654, in can_be_executed_by
    self._cmd = py_db.cmd_factory.make_get_thread_stack_message(
  File "/home/username/.local/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py", line 284, in make_get_thread_stack_message
    end = min(start + levels, total_frames)
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```
The error occured with the current HEAD of main-branch (commit 0a40cab) and with the version 1.6.0  hosted on PyPi. 
The cause of it seems to be that `start_frame` is used for addition in order to determine a stackframe number, although it is was None. 

This PR fixes the issue. 

Thanks already in advance for considering this small contribution. 

Best regards, 
jgru

