### PR TITLE
GH-861: Support-Python-3.11-frozen-modules

### DIFF
--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -10,9 +10,6 @@ from debugpy import launcher
 from debugpy.common import json
 from debugpy.launcher import debuggee
 
-# see https://github.com/microsoft/debugpy/issues/861
-PYTHON_311 = sys.version_info[:2] == (3, 11)
-
 def launch_request(request):
     debug_options = set(request("debugOptions", json.array(str)))
 
@@ -40,11 +37,11 @@ def launch_request(request):
     python = request("python", json.array(str, size=(1,)))
     cmdline = list(python)
 
-    # see https://github.com/microsoft/debugpy/issues/861
-    if PYTHON_311:
-        cmdline += ["-X", "frozen_modules=off"]
-
     if not request("noDebug", json.default(False)):
+        # see https://github.com/microsoft/debugpy/issues/861
+        if sys.version_info[:2] >= (3, 11):
+            cmdline += ["-X", "frozen_modules=off"]
+
         port = request("port", int)
         cmdline += [
             os.path.dirname(debugpy.__file__),

--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -10,6 +10,8 @@ from debugpy import launcher
 from debugpy.common import json
 from debugpy.launcher import debuggee
 
+# see https://github.com/microsoft/debugpy/issues/861
+PYTHON_311 = sys.version_info[:2] == (3, 11)
 
 def launch_request(request):
     debug_options = set(request("debugOptions", json.array(str)))
@@ -37,6 +39,10 @@ def launch_request(request):
 
     python = request("python", json.array(str, size=(1,)))
     cmdline = list(python)
+
+    # see https://github.com/microsoft/debugpy/issues/861
+    if PYTHON_311:
+        cmdline += ["-X", "frozen_modules=off"]
 
     if not request("noDebug", json.default(False)):
         port = request("port", int)


### PR DESCRIPTION
Add "-X=frozen_modules=off" to cpython interpreter when version==3.11
see https://github.com/microsoft/debugpy/issues/861