### PR TITLE
Fix #865: Debugging through poetry drops subprocess

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,9 @@ exclude = '''
 | ^/src/debugpy/_version.py
 )
 '''
+
+[tool.pyright]
+pythonVersion = "3.7"
+include = ["src"]
+extraPaths = ["src/debugpy/_vendored/pydevd"]
+ignore = ["src/debugpy/_vendored/pydevd", "src/debugpy/_version.py"]

--- a/src/debugpy/common/messaging.py
+++ b/src/debugpy/common/messaging.py
@@ -9,6 +9,8 @@ responses, and events.
 https://microsoft.github.io/debug-adapter-protocol/overview#base-protocol
 """
 
+from __future__ import annotations
+
 import collections
 import contextlib
 import functools
@@ -460,7 +462,7 @@ class Message(object):
         raise NotImplementedError
 
     @property
-    def payload(self):
+    def payload(self) -> MessageDict:
         """Payload of the message - self.body or self.arguments, depending on the
         message type.
         """

--- a/src/debugpy/public_api.py
+++ b/src/debugpy/public_api.py
@@ -3,6 +3,7 @@
 # for license information.
 
 from __future__ import annotations
+
 import functools
 import typing
 
@@ -17,10 +18,7 @@ from debugpy import _version
 # than 72 characters per line! - and must be readable when retrieved via help().
 
 
-# Type aliases and protocols must be guarded to avoid runtime errors due to unsupported
-# syntax in Python <3.9; since they aren't annotations, they're eagerly evaluated!
-if typing.TYPE_CHECKING:
-    Endpoint = tuple[str, int]
+Endpoint = typing.Tuple[str, int]
 
 
 def _api(cancelable=False):
@@ -57,7 +55,7 @@ def log_to(__path: str) -> None:
 
 
 @_api()
-def configure(__properties: dict[str] = None, **kwargs) -> None:
+def configure(__properties: dict[str, typing.Any] | None = None, **kwargs) -> None:
     """Sets debug configuration properties that cannot be set in the
     "attach" request, because they must be applied as early as possible
     in the process being debugged.
@@ -113,7 +111,7 @@ def listen(__endpoint: Endpoint | int) -> Endpoint:
 
 
 @_api()
-def connect(__endpoint: Endpoint | int, *, access_token: str = None) -> Endpoint:
+def connect(__endpoint: Endpoint | int, *, access_token: str | None = None) -> Endpoint:
     """Tells an existing debug adapter instance that is listening on the
     specified address to debug this process.
 

--- a/tests/debug/session.py
+++ b/tests/debug/session.py
@@ -474,6 +474,7 @@ class Session(object):
         if event.event == "exited":
             self.observe(occ)
             self.exit_code = event("exitCode", int)
+            self.exit_reason = event("reason", str, optional=True)
             assert self.exit_code == self.expected_exit_code
         elif event.event == "debugpyAttach":
             self.observe(occ)

--- a/tests/timeline.py
+++ b/tests/timeline.py
@@ -295,7 +295,7 @@ class Timeline(object):
             # Otherwise, break it down expectation by expectation.
             message += ":"
             for exp, reason in reasons.items():
-                message += "\n\n   where {exp!r}\n      == {reason!r}"
+                message += f"\n\n   where {exp!r}\n      == {reason!r}"
         else:
             message += "."
 


### PR DESCRIPTION
Handle "exited" { "pydevdReason": "processReplaced" } appropriately.

Add test for os.exec() in-place process replacement.