### PR TITLE
Fix compiling attach library from source

### DIFF
--- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/common/python.h
+++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/common/python.h
@@ -19,6 +19,8 @@
 
 #include "../common/py_version.hpp"
 
+#include <cstdint>
+
 #ifndef _WIN32
 typedef unsigned int DWORD;
 typedef ssize_t SSIZE_T;


### PR DESCRIPTION
Fixes compiling the attach libraries with `src/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac/compile_linux.sh`


[#963](https://github.com/microsoft/debugpy/pull/963/files#diff-ce2b938b8b49681a9f3df5dd146f24553215f7d9a7e85a656f64b94ade1ea038R128) added standard integer types to `./src/debugpy/_vendored/pydevd/pydevd_attach_to_process/common/python.h` without an explicit import.