### PR TITLE
Fix #981: "repr was slow" warning is modal in Visual Studio

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py
@@ -293,7 +293,7 @@ class NetCommandFactoryJson(NetCommandFactory):
 
     @overrides(NetCommandFactory.make_warning_message)
     def make_warning_message(self, msg):
-        category = 'important'
+        category = 'console'
         body = OutputEventBody(msg, category)
         event = OutputEvent(body)
         return NetCommand(CMD_WRITE_TO_CONSOLE, 0, event, is_json=True)


### PR DESCRIPTION
Use the "console" category for warnings.