### PR TITLE
Custom subprocess environment variables for Python embedded

### DIFF
--- a/src/debugpy/server/api.py
+++ b/src/debugpy/server/api.py
@@ -22,8 +22,8 @@ _tls = threading.local()
 _config = {
     "qt": "none",
     "subProcess": True,
-    "subProcessEnv": {},
     "python": sys.executable,
+    "pythonEnv": {},
 }
 
 _config_valid_values = {
@@ -191,9 +191,9 @@ def listen(address, settrace_kwargs):
 
         # On embedded applications, environment variables might not contain
         # Python environment settings.
-        subproc_env = _config.get("subProcessEnv")
-        if not bool(subproc_env):
-            subproc_env = None
+        python_env = _config.get("pythonEnv")
+        if not bool(python_env):
+            python_env = None
 
         # Adapter will outlive this process, so we shouldn't wait for it. However, we
         # need to ensure that the Popen instance for it doesn't get garbage-collected
@@ -202,7 +202,7 @@ def listen(address, settrace_kwargs):
         try:
             global _adapter_process
             _adapter_process = subprocess.Popen(
-                adapter_args, close_fds=True, creationflags=creationflags, env=subproc_env
+                adapter_args, close_fds=True, creationflags=creationflags, env=python_env
             )
             if os.name == "posix":
                 # It's going to fork again to daemonize, so we need to wait on it to

--- a/src/debugpy/server/api.py
+++ b/src/debugpy/server/api.py
@@ -22,6 +22,7 @@ _tls = threading.local()
 _config = {
     "qt": "none",
     "subProcess": True,
+    "subProcessEnv": {},
     "python": sys.executable,
 }
 
@@ -188,6 +189,12 @@ def listen(address, settrace_kwargs):
             creationflags |= 0x08000000  # CREATE_NO_WINDOW
             creationflags |= 0x00000200  # CREATE_NEW_PROCESS_GROUP
 
+        # On embedded applications, environment variables might not contain
+        # Python environment settings.
+        subproc_env = _config.get("subProcessEnv")
+        if not bool(subproc_env):
+            subproc_env = None
+
         # Adapter will outlive this process, so we shouldn't wait for it. However, we
         # need to ensure that the Popen instance for it doesn't get garbage-collected
         # by holding a reference to it in a non-local variable, to avoid triggering
@@ -195,7 +202,7 @@ def listen(address, settrace_kwargs):
         try:
             global _adapter_process
             _adapter_process = subprocess.Popen(
-                adapter_args, close_fds=True, creationflags=creationflags
+                adapter_args, close_fds=True, creationflags=creationflags, env=subproc_env
             )
             if os.name == "posix":
                 # It's going to fork again to daemonize, so we need to wait on it to


### PR DESCRIPTION
Python embedded might not have environment variables set to Python paths and host application might not want to change its own environment settings.

For example (Android):
```
env = { 
  "LD_LIBRARY_PATH": shared_library_path,
  "PYTHONHOME": python_home,
  "PATH": python_executable_path,
  "TMPDIR": tmp
}
debugpy.configure(subProcessEnv=env)
```
Tested on Windows, Linux, MacOS (Intel and M1) and Android.