### PR TITLE
Fix #357, #1001

### DIFF
--- a/src/debugpy/adapter/launchers.py
+++ b/src/debugpy/adapter/launchers.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 from debugpy import adapter, common
-from debugpy.common import json, log, messaging, sockets
+from debugpy.common import log, messaging, sockets
 from debugpy.adapter import components, servers
 
 
@@ -70,6 +70,7 @@ def spawn_debuggee(
     launcher_path,
     adapter_host,
     args,
+    shell_expand_args,
     cwd,
     console,
     console_title,
@@ -119,16 +120,6 @@ def spawn_debuggee(
         if console == "internalConsole":
             log.info("{0} spawning launcher: {1!r}", session, cmdline)
             try:
-                for i, arg in enumerate(cmdline):
-                    try:
-                        cmdline[i] = arg
-                    except UnicodeEncodeError as exc:
-                        raise start_request.cant_handle(
-                            "Invalid command line argument {0}: {1}",
-                            json.repr(arg),
-                            exc,
-                        )
-
                 # If we are talking to the client over stdio, sys.stdin and sys.stdout
                 # are redirected to avoid mangling the DAP message stream. Make sure
                 # the launcher also respects that.
@@ -154,6 +145,8 @@ def spawn_debuggee(
             }
             if cwd is not None:
                 request_args["cwd"] = cwd
+            if shell_expand_args:
+                request_args["argsCanBeInterpretedByShell"] = True
             try:
                 # It is unspecified whether this request receives a response immediately, or only
                 # after the spawned command has completed running, so do not block waiting for it.

--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -10,6 +10,7 @@ from debugpy import launcher
 from debugpy.common import json
 from debugpy.launcher import debuggee
 
+
 def launch_request(request):
     debug_options = set(request("debugOptions", json.array(str)))
 
@@ -67,12 +68,9 @@ def launch_request(request):
         debugpy_args = request("debugpyArgs", json.array(str))
         cmdline += debugpy_args
 
-    # Further arguments can come via two channels: the launcher's own command line, or
-    # "args" in the request; effective arguments are concatenation of these two in order.
-    # Arguments for debugpy (such as -m) always come via CLI, but those specified by the
-    # user via "args" are passed differently by the adapter depending on "argsExpansion".
+    # Use the copy of arguments that was propagated via the command line rather than
+    # "args" in the request itself, to allow for shell expansion.
     cmdline += sys.argv[1:]
-    cmdline += request("args", json.array(str))
 
     process_name = request("processName", sys.executable)
 

--- a/tests/debug/config.py
+++ b/tests/debug/config.py
@@ -49,7 +49,6 @@ class DebugConfig(MutableMapping):
         "type": (),
         # Launch
         "args": [],
-        "argsExpansion": "shell",
         "code": (),
         "console": "internal",
         "cwd": (),

--- a/tests/debug/runners.py
+++ b/tests/debug/runners.py
@@ -325,9 +325,12 @@ debugpy.connect({(host, port)!r})
 attach_listen.host = "127.0.0.1"
 attach_listen.port = net.get_test_server_port(5478, 5600)
 
-all_launch_terminal = [launch["integratedTerminal"], launch["externalTerminal"]]
+all_launch_terminal = [
+    launch.with_options(console="integratedTerminal"),
+    launch.with_options(console="externalTerminal"),
+]
 
-all_launch = [launch["internalConsole"]] + all_launch_terminal
+all_launch = [launch.with_options(console="internalConsole")] + all_launch_terminal
 
 all_attach_listen = [attach_listen["api"], attach_listen["cli"]]
 

--- a/tests/debug/session.py
+++ b/tests/debug/session.py
@@ -490,7 +490,11 @@ class Session(object):
     def _process_request(self, request):
         self.timeline.record_request(request, block=False)
         if request.command == "runInTerminal":
-            args = request("args", json.array(str))
+            args = request("args", json.array(str, vectorize=True))
+            if len(args) > 0 and request("argsCanBeInterpretedByShell", False):
+                # The final arg is a string that contains multiple actual arguments.
+                last_arg = args.pop()
+                args += last_arg.split()
             cwd = request("cwd", ".")
             env = request("env", json.object(str))
             try:
@@ -557,6 +561,7 @@ class Session(object):
                 "columnsStartAt1": True,
                 "supportsVariableType": True,
                 "supportsRunInTerminalRequest": True,
+                "supportsArgsCanBeInterpretedByShell": True,
             },
         )
 

--- a/tests/debug/targets.py
+++ b/tests/debug/targets.py
@@ -46,6 +46,14 @@ class Target(object):
         raise NotImplementedError
 
     @property
+    def argslist(self):
+        args = self.args
+        if isinstance(args, str):
+            return [args]
+        else:
+            return list(args)
+
+    @property
     def co_filename(self):
         """co_filename of code objects created at runtime from the source that this
         Target describes, assuming no path mapping.
@@ -121,9 +129,11 @@ class Program(Target):
 
     def cli(self, env):
         if self._cwd:
-            return [self._get_relative_program()] + list(self.args)
+            cli = [self._get_relative_program()]
         else:
-            return [self.filename.strpath] + list(self.args)
+            cli = [self.filename.strpath]
+        cli += self.argslist
+        return cli
 
 
 class Module(Target):
@@ -150,7 +160,7 @@ class Module(Target):
     def cli(self, env):
         if self.filename is not None:
             env.prepend_to("PYTHONPATH", self.filename.dirname)
-        return ["-m", self.name] + list(self.args)
+        return ["-m", self.name] + self.argslist
 
 
 class Code(Target):
@@ -176,7 +186,7 @@ class Code(Target):
         session.config["args"] = self.args
 
     def cli(self, env):
-        return ["-c", self.code] + list(self.args)
+        return ["-c", self.code] + self.argslist
 
     @property
     def co_filename(self):


### PR DESCRIPTION
Fix #1001: Enable controlling shell expansion via "argsCanBeInterpretedByShell"

Fix #357: "argsExpansion" does not do what it says in VSCode

Treat non-array "args" in debug config as a request to prevent shell argument escaping and allow shell expansion.

Remove "argsExpansion".