### PR TITLE
Add DEBUGPY_TRACE_DEBUGPY variable to allow debugpy to debug itself

### DIFF
--- a/src/debugpy/common/log.py
+++ b/src/debugpy/common/log.py
@@ -58,7 +58,7 @@ class LogFile(object):
                 platform.machine(),
                 platform.python_implementation(),
                 platform.python_version(),
-                64 if sys.maxsize > 2**32 else 32,
+                64 if sys.maxsize > 2 ** 32 else 32,
                 debugpy.__version__,
                 _to_files=[self],
             )

--- a/src/debugpy/common/messaging.py
+++ b/src/debugpy/common/messaging.py
@@ -21,7 +21,7 @@ import sys
 import threading
 
 from debugpy.common import json, log, util
-from debugpy.common.util import skip_trace
+from debugpy.common.util import hide_thread_from_debugger
 
 
 class JsonIOError(IOError):
@@ -1150,10 +1150,8 @@ class JsonMessageChannel(object):
             target=self._parse_incoming_messages, name=f"{self} message parser"
         )
 
-        if skip_trace():
-            self._parser_thread.pydev_do_not_trace = True
-            self._parser_thread.is_pydev_daemon_thread = True
-            self._parser_thread.daemon = True
+        hide_thread_from_debugger(self._parser_thread)
+        self._parser_thread.daemon = True
         self._parser_thread.start()
 
     def wait(self):

--- a/src/debugpy/common/messaging.py
+++ b/src/debugpy/common/messaging.py
@@ -21,6 +21,7 @@ import sys
 import threading
 
 from debugpy.common import json, log, util
+from debugpy.common.util import skip_trace
 
 
 class JsonIOError(IOError):
@@ -1148,9 +1149,11 @@ class JsonMessageChannel(object):
         self._parser_thread = threading.Thread(
             target=self._parse_incoming_messages, name=f"{self} message parser"
         )
-        self._parser_thread.pydev_do_not_trace = True
-        self._parser_thread.is_pydev_daemon_thread = True
-        self._parser_thread.daemon = True
+
+        if skip_trace():
+            self._parser_thread.pydev_do_not_trace = True
+            self._parser_thread.is_pydev_daemon_thread = True
+            self._parser_thread.daemon = True
         self._parser_thread.start()
 
     def wait(self):

--- a/src/debugpy/common/sockets.py
+++ b/src/debugpy/common/sockets.py
@@ -7,7 +7,7 @@ import sys
 import threading
 
 from debugpy.common import log
-from debugpy.common.util import skip_trace
+from debugpy.common.util import hide_thread_from_debugger
 
 
 def create_server(host, port=0, backlog=socket.SOMAXCONN, timeout=None):
@@ -115,10 +115,8 @@ def serve(name, handler, host, port=0, backlog=socket.SOMAXCONN, timeout=None):
             handler(sock)
 
     thread = threading.Thread(target=accept_worker)
-    if skip_trace():
-        thread.daemon = True
-        thread.pydev_do_not_trace = True
-        thread.is_pydev_daemon_thread = True
+    thread.daemon = True
+    hide_thread_from_debugger(thread)
     thread.start()
 
     return listener

--- a/src/debugpy/common/sockets.py
+++ b/src/debugpy/common/sockets.py
@@ -7,6 +7,7 @@ import sys
 import threading
 
 from debugpy.common import log
+from debugpy.common.util import skip_trace
 
 
 def create_server(host, port=0, backlog=socket.SOMAXCONN, timeout=None):
@@ -114,9 +115,10 @@ def serve(name, handler, host, port=0, backlog=socket.SOMAXCONN, timeout=None):
             handler(sock)
 
     thread = threading.Thread(target=accept_worker)
-    thread.daemon = True
-    thread.pydev_do_not_trace = True
-    thread.is_pydev_daemon_thread = True
+    if skip_trace():
+        thread.daemon = True
+        thread.pydev_do_not_trace = True
+        thread.is_pydev_daemon_thread = True
     thread.start()
 
     return listener

--- a/src/debugpy/common/util.py
+++ b/src/debugpy/common/util.py
@@ -150,16 +150,15 @@ def srcnameof(obj):
     return name
 
 
-def skip_trace():
-    """Returns True if tracing should be skipped for the current thread."""
+def hide_debugpy_internals():
+    """Returns True if the caller should hide something from debugpy."""
     return "DEBUGPY_TRACE_DEBUGPY" not in os.environ
 
 
-def disable_tracing(thread):
+def hide_thread_from_debugger(thread):
     """Disables tracing for the given thread if DEBUGPY_TRACE_DEBUGPY is not set.
     DEBUGPY_TRACE_DEBUGPY is used to debug debugpy with debugpy
     """
-    if skip_trace():
+    if hide_debugpy_internals():
         thread.pydev_do_not_trace = True
         thread.is_pydev_daemon_thread = True
-        thread.daemon = True

--- a/src/debugpy/common/util.py
+++ b/src/debugpy/common/util.py
@@ -148,3 +148,18 @@ def srcnameof(obj):
         name += ")"
 
     return name
+
+
+def skip_trace():
+    """Returns True if tracing should be skipped for the current thread."""
+    return "DEBUGPY_TRACE_DEBUGPY" not in os.environ
+
+
+def disable_tracing(thread):
+    """Disables tracing for the given thread if DEBUGPY_TRACE_DEBUGPY is not set.
+    DEBUGPY_TRACE_DEBUGPY is used to debug debugpy with debugpy
+    """
+    if skip_trace():
+        thread.pydev_do_not_trace = True
+        thread.is_pydev_daemon_thread = True
+        thread.daemon = True

--- a/src/debugpy/launcher/handlers.py
+++ b/src/debugpy/launcher/handlers.py
@@ -10,6 +10,7 @@ from debugpy import launcher
 from debugpy.common import json
 from debugpy.launcher import debuggee
 
+
 def launch_request(request):
     debug_options = set(request("debugOptions", json.array(str)))
 

--- a/src/debugpy/server/api.py
+++ b/src/debugpy/server/api.py
@@ -14,7 +14,7 @@ from debugpy import adapter
 from debugpy.common import json, log, sockets
 from _pydevd_bundle.pydevd_constants import get_global_debugger
 from pydevd_file_utils import absolute_path
-from debugpy.common.util import skip_trace
+from debugpy.common.util import hide_debugpy_internals
 
 _tls = threading.local()
 
@@ -129,7 +129,7 @@ def _starts_debugging(func):
             "patch_multiprocessing": _config.get("subProcess", True),
         }
 
-        if skip_trace():
+        if hide_debugpy_internals():
             debugpy_path = os.path.dirname(absolute_path(debugpy.__file__))
             settrace_kwargs["dont_trace_start_patterns"] = (debugpy_path,)
             settrace_kwargs["dont_trace_end_patterns"] = (str("debugpy_launcher.py"),)

--- a/src/debugpy/server/api.py
+++ b/src/debugpy/server/api.py
@@ -14,7 +14,7 @@ from debugpy import adapter
 from debugpy.common import json, log, sockets
 from _pydevd_bundle.pydevd_constants import get_global_debugger
 from pydevd_file_utils import absolute_path
-
+from debugpy.common.util import skip_trace
 
 _tls = threading.local()
 
@@ -129,9 +129,10 @@ def _starts_debugging(func):
             "patch_multiprocessing": _config.get("subProcess", True),
         }
 
-        debugpy_path = os.path.dirname(absolute_path(debugpy.__file__))
-        settrace_kwargs["dont_trace_start_patterns"] = (debugpy_path,)
-        settrace_kwargs["dont_trace_end_patterns"] = (str("debugpy_launcher.py"),)
+        if skip_trace():
+            debugpy_path = os.path.dirname(absolute_path(debugpy.__file__))
+            settrace_kwargs["dont_trace_start_patterns"] = (debugpy_path,)
+            settrace_kwargs["dont_trace_end_patterns"] = (str("debugpy_launcher.py"),)
 
         try:
             return func(address, settrace_kwargs, **kwargs)

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -109,7 +109,7 @@ def set_address(mode):
             port = int(port)
         except Exception:
             port = -1
-        if not (0 <= port < 2**16):
+        if not (0 <= port < 2 ** 16):
             raise ValueError("invalid port number")
 
         options.mode = mode


### PR DESCRIPTION
To allow using debugpy to debug itself (well at least the adapter), added a new environment variable that skips setting `dont_trace_start_patterns` and setting thread flags that hide threads.