### PR TITLE
Missed a thread to allow debugging

### DIFF
--- a/src/debugpy/common/messaging.py
+++ b/src/debugpy/common/messaging.py
@@ -1410,8 +1410,7 @@ class JsonMessageChannel(object):
                     target=self._run_handlers,
                     name=f"{self} message handler",
                 )
-                self._handler_thread.pydev_do_not_trace = True
-                self._handler_thread.is_pydev_daemon_thread = True
+                hide_thread_from_debugger(self._handler_thread)
                 self._handler_thread.start()
 
     def _run_handlers(self):


### PR DESCRIPTION
In https://github.com/microsoft/debugpy/pull/1007 I turned of hiding of threads based on an environment variable.

I missed a spot. Hiding this thread makes it hard to watch the message handlers.