### PR TITLE
Provide pydevd.log_to() to change the file to log to. WIP #1030

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydev_bundle/pydev_monkey.py
+++ b/src/debugpy/_vendored/pydevd/_pydev_bundle/pydev_monkey.py
@@ -4,7 +4,7 @@ import re
 import sys
 from _pydev_bundle._pydev_saved_modules import threading
 from _pydevd_bundle.pydevd_constants import get_global_debugger, IS_WINDOWS, IS_JYTHON, get_current_thread_id, \
-    sorted_dict_repr, set_global_debugger
+    sorted_dict_repr, set_global_debugger, DebugInfoHolder
 from _pydev_bundle import pydev_log
 from contextlib import contextmanager
 from _pydevd_bundle import pydevd_constants
@@ -68,6 +68,13 @@ def _get_setup_updated_with_protocol_and_ppid(setup, is_exec=False):
 
     else:
         pydev_log.debug('Unexpected protocol: %s', protocol)
+
+    if DebugInfoHolder.PYDEVD_DEBUG_FILE:
+        setup['log-file'] = DebugInfoHolder.PYDEVD_DEBUG_FILE
+
+    if DebugInfoHolder.DEBUG_TRACE_LEVEL:
+        setup['log-level'] = DebugInfoHolder.DEBUG_TRACE_LEVEL
+
     return setup
 
 

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
@@ -551,8 +551,7 @@ class PyDevdAPI(object):
         if not supported_type:
             raise NameError(breakpoint_type)
 
-        if DebugInfoHolder.DEBUG_TRACE_BREAKPOINTS > 0:
-            pydev_log.debug('Added breakpoint:%s - line:%s - func_name:%s\n', canonical_normalized_filename, line, func_name)
+        pydev_log.debug('Added breakpoint:%s - line:%s - func_name:%s\n', canonical_normalized_filename, line, func_name)
 
         if canonical_normalized_filename in file_to_id_to_breakpoint:
             id_to_pybreakpoint = file_to_id_to_breakpoint[canonical_normalized_filename]
@@ -672,10 +671,10 @@ class PyDevdAPI(object):
         else:
             try:
                 id_to_pybreakpoint = file_to_id_to_breakpoint.get(canonical_normalized_filename, {})
-                if DebugInfoHolder.DEBUG_TRACE_BREAKPOINTS > 0:
+                if DebugInfoHolder.DEBUG_TRACE_LEVEL >= 1:
                     existing = id_to_pybreakpoint[breakpoint_id]
                     pydev_log.info('Removed breakpoint:%s - line:%s - func_name:%s (id: %s)\n' % (
-                        canonical_normalized_filename, existing.line, existing.func_name.encode('utf-8'), breakpoint_id))
+                        canonical_normalized_filename, existing.line, existing.func_name, breakpoint_id))
 
                 del id_to_pybreakpoint[breakpoint_id]
                 py_db.consolidate_breakpoints(canonical_normalized_filename, id_to_pybreakpoint, file_to_line_to_breakpoints)

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -274,13 +274,14 @@ class ReaderThread(PyDBDaemonThread):
                 if hasattr(line, 'decode'):
                     line = line.decode('utf-8')
 
-                if DebugInfoHolder.DEBUG_RECORD_SOCKET_READS:
-                    pydev_log.critical(u'debugger: received >>%s<<\n' % (line,))
+                if DebugInfoHolder.DEBUG_TRACE_LEVEL >= 3:
+                    pydev_log.debug('debugger: received >>%s<<\n', line)
 
-                args = line.split(u'\t', 2)
+                args = line.split('\t', 2)
                 try:
                     cmd_id = int(args[0])
-                    pydev_log.debug('Received command: %s %s\n' % (ID_TO_MEANING.get(str(cmd_id), '???'), line,))
+                    if DebugInfoHolder.DEBUG_TRACE_LEVEL >= 3:
+                        pydev_log.debug('Received command: %s %s\n', ID_TO_MEANING.get(str(cmd_id), '???'), line)
                     self.process_command(cmd_id, int(args[1]), args[2])
                 except:
                     if sys is not None and pydev_log_exception is not None:  # Could happen at interpreter shutdown
@@ -1351,12 +1352,12 @@ def internal_get_completions(dbg, seq, thread_id, frame_id, act_tok, line=-1, co
     try:
         remove_path = None
         try:
-            qualifier = u''
+            qualifier = ''
             if column >= 0:
                 token_and_qualifier = extract_token_and_qualifier(act_tok, line, column)
                 act_tok = token_and_qualifier[0]
                 if act_tok:
-                    act_tok += u'.'
+                    act_tok += '.'
                 qualifier = token_and_qualifier[1]
 
             frame = dbg.find_frame(thread_id, frame_id)

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_command_line_handling.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_command_line_handling.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 
 class ArgHandlerWithParam:
@@ -68,8 +69,11 @@ ACCEPTED_ARG_HANDLERS = [
     ArgHandlerWithParam('access-token'),
     ArgHandlerWithParam('client-access-token'),
 
+    # Logging
+    ArgHandlerWithParam('log-file'),
+    ArgHandlerWithParam('log-level', int, 0),
+
     ArgHandlerBool('server'),
-    ArgHandlerBool('DEBUG_RECORD_SOCKET_READS'),
     ArgHandlerBool('multiproc'),  # Used by PyCharm (reuses connection: ssh tunneling)
     ArgHandlerBool('multiprocess'),  # Used by PyDev (creates new connection to ide)
     ArgHandlerBool('save-signatures'),
@@ -132,6 +136,8 @@ def process_command_line(argv):
     setup['file'] = ''
     setup['qt-support'] = ''
 
+    initial_argv = tuple(argv)
+
     i = 0
     del argv[0]
     while i < len(argv):
@@ -169,10 +175,9 @@ def process_command_line(argv):
             i = len(argv)  # pop out, file is our last argument
 
         elif argv[i] == '--DEBUG':
-            from pydevd import set_debug
-            del argv[i]
-            set_debug(setup)
+            sys.stderr.write('pydevd: --DEBUG parameter deprecated. Use `--debug-level=3` instead.\n')
 
         else:
-            raise ValueError("Unexpected option: " + argv[i])
+            raise ValueError("Unexpected option: %s when processing: %s" % (argv[i], initial_argv))
     return setup
+

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_constants.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_constants.py
@@ -39,10 +39,6 @@ class DebugInfoHolder:
     # General information
     DEBUG_TRACE_LEVEL = 0  # 0 = critical, 1 = info, 2 = debug, 3 = verbose
 
-    # Flags to debug specific points of the code.
-    DEBUG_RECORD_SOCKET_READS = False
-    DEBUG_TRACE_BREAKPOINTS = -1
-
     PYDEVD_DEBUG_FILE = None
 
 
@@ -292,7 +288,6 @@ DEFAULT_VALUE = "__pydevd_value_async"
 ASYNC_EVAL_TIMEOUT_SEC = 60
 NEXT_VALUE_SEPARATOR = "__pydev_val__"
 BUILTINS_MODULE_NAME = 'builtins'
-SHOW_DEBUG_INFO_ENV = is_true_in_env(('PYCHARM_DEBUG', 'PYDEV_DEBUG', 'PYDEVD_DEBUG'))
 
 # Pandas customization.
 PANDAS_MAX_ROWS = as_int_in_env('PYDEVD_PANDAS_MAX_ROWS', 60)
@@ -335,11 +330,11 @@ EXCEPTION_TYPE_UNHANDLED = 'UNHANDLED'
 EXCEPTION_TYPE_USER_UNHANDLED = 'USER_UNHANDLED'
 EXCEPTION_TYPE_HANDLED = 'HANDLED'
 
+SHOW_DEBUG_INFO_ENV = is_true_in_env(('PYCHARM_DEBUG', 'PYDEV_DEBUG', 'PYDEVD_DEBUG'))
+
 if SHOW_DEBUG_INFO_ENV:
     # show debug info before the debugger start
-    DebugInfoHolder.DEBUG_RECORD_SOCKET_READS = True
     DebugInfoHolder.DEBUG_TRACE_LEVEL = 3
-    DebugInfoHolder.DEBUG_TRACE_BREAKPOINTS = 1
 
 DebugInfoHolder.PYDEVD_DEBUG_FILE = os.getenv('PYDEVD_DEBUG_FILE')
 

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -163,7 +163,7 @@ class PyDevJsonCommandProcessor(object):
                 return NetCommand(CMD_RETURN, 0, error_response, is_json=True)
 
         else:
-            if DebugInfoHolder.DEBUG_RECORD_SOCKET_READS and DebugInfoHolder.DEBUG_TRACE_LEVEL >= 1:
+            if DebugInfoHolder.DEBUG_TRACE_LEVEL >= 1:
                 pydev_log.info('Process %s: %s\n' % (
                     request.__class__.__name__, json.dumps(request.to_dict(update_ids_to_dap=True), indent=4, sort_keys=True),))
 

--- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/attach_script.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/attach_script.py
@@ -168,8 +168,6 @@ def attach(port, host, protocol=''):
         if py_db is not None:
             py_db.dispose_and_kill_all_pydevd_threads(wait=False)
 
-        # pydevd.DebugInfoHolder.DEBUG_RECORD_SOCKET_READS = True
-        # pydevd.DebugInfoHolder.DEBUG_TRACE_BREAKPOINTS = 3
         # pydevd.DebugInfoHolder.DEBUG_TRACE_LEVEL = 3
         pydevd.settrace(
             port=port,

--- a/src/debugpy/_vendored/pydevd/tests_python/debugger_fixtures.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/debugger_fixtures.py
@@ -418,7 +418,7 @@ def case_setup_multiprocessing(debugger_runner_simple):
 
             def update_command_line_args(writer, args):
                 ret = debugger_unittest.AbstractWriterThread.update_command_line_args(writer, args)
-                ret.insert(ret.index('--DEBUG_RECORD_SOCKET_READS'), '--multiprocess')
+                ret.insert(ret.index('--client'), '--multiprocess')
                 return ret
 
             WriterThread.update_command_line_args = update_command_line_args

--- a/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
@@ -397,7 +397,6 @@ class DebuggerRunner(object):
         localhost = pydev_localhost.get_localhost()
         ret = [
             writer.get_pydevd_file(),
-            '--DEBUG_RECORD_SOCKET_READS',
         ]
 
         if not IS_PY36_OR_GREATER or not IS_CPYTHON or not TEST_CYTHON:

--- a/src/debugpy/_vendored/pydevd/tests_python/resources/_debugger_case_logging.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/resources/_debugger_case_logging.py
@@ -1,0 +1,63 @@
+import subprocess
+import sys
+import json
+from _pydev_bundle import pydev_log
+import os
+import io
+
+
+def gen_debug_info():
+    from _pydevd_bundle.pydevd_constants import DebugInfoHolder
+    dct = {}
+    for name in (
+        'PYDEVD_DEBUG_FILE',
+        'DEBUG_TRACE_LEVEL',
+        ):
+        dct[name] = getattr(DebugInfoHolder, name)
+
+    return dct
+
+
+if __name__ == "__main__":
+    if '-print-debug' in sys.argv:
+        info = gen_debug_info()  # break on 2nd process
+        pydev_log.info('Something in print-debug')
+
+        print('>>> print-debug pid: %s' % os.getpid())
+        print(json.dumps(info))
+
+    else:
+        # Note: when running tests we usually have logging setup,
+        # so, we create a context so that our changes are restored
+        # when it finishes (as the `log_to` function will just reset
+        # whatever is there).
+        s = io.StringIO()
+        with pydev_log.log_context(trace_level=3, stream=s):
+            target_log_file = os.getenv('TARGET_LOG_FILE')
+
+            pydev_log.log_to(target_log_file, 1)
+            new_debug_info = gen_debug_info()
+            subprocess_pid = None
+            with subprocess.Popen(
+                    [sys.executable, __file__, '-print-debug'],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                ) as process:
+                subprocess_pid = process.pid
+                stdout, stderr = process.communicate(input)
+
+            output = stdout.decode('utf-8')
+            pydev_log.info('Something in initial')
+
+        log_contents = open(pydev_log._compute_filename_with_pid(target_log_file)).read()
+        assert 'Something in initial' in log_contents, 'Did not find "Something in initial" in %s' % (log_contents,)
+
+        log_contents = open(pydev_log._compute_filename_with_pid(target_log_file, pid=subprocess_pid)).read()
+        assert 'Something in print-debug' in log_contents, 'Did not find "Something in print-debug" in %s' % (log_contents,)
+
+        output = ''.join(output.splitlines(keepends=True)[1:])  # Remove the first line
+        loaded_debug_info = json.loads(output)
+        assert loaded_debug_info == new_debug_info, 'Expected %s. Found: %s' % (new_debug_info, loaded_debug_info)
+        print('>>> Initial pid: %s' % os.getpid())
+        print(output)
+        print('TEST SUCEEDED')

--- a/src/debugpy/_vendored/pydevd/tests_python/test_debugger.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_debugger.py
@@ -3836,10 +3836,12 @@ def test_step_over_my_code_global_setting_and_explicit_include(case_setup):
 def test_access_token(case_setup):
 
     def update_command_line_args(self, args):
-        args.insert(2, '--access-token')
-        args.insert(3, 'bar123')
-        args.insert(2, '--client-access-token')
-        args.insert(3, 'foo234')
+        i = args.index('--client')
+        assert i > 0
+        args.insert(i, '--access-token')
+        args.insert(i + 1, 'bar123')
+        args.insert(i, '--client-access-token')
+        args.insert(i + 1, 'foo234')
         return args
 
     with case_setup.test_file('_debugger_case_print.py', update_command_line_args=update_command_line_args) as writer:

--- a/src/debugpy/_vendored/pydevd/tests_python/test_utilities.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_utilities.py
@@ -255,10 +255,7 @@ def _check_tracing_other_threads():
     import pydevd_tracing
     import time
     from tests_python.debugger_unittest import wait_for_condition
-    try:
-        import _thread
-    except ImportError:
-        import thread as _thread
+    import _thread
 
     # This method is called in a subprocess, so, make sure we exit properly even if we somehow
     # deadlock somewhere else.


### PR DESCRIPTION
Note that this PR still doesn't change debugpy itself.

It just updated pydevd so that debugpy has the means to change the pydevd log file -- while the change should be straightforward I won't be able to finish that part this week (if no one gets it until next Thursday I'll take a look at it).