### PR TITLE
Raise to 0.5s default timeout which notifies about slow access.

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_constants.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_constants.py
@@ -295,7 +295,7 @@ PANDAS_MAX_COLS = as_int_in_env('PYDEVD_PANDAS_MAX_COLS', 10)
 PANDAS_MAX_COLWIDTH = as_int_in_env('PYDEVD_PANDAS_MAX_COLWIDTH', 50)
 
 # If getting an attribute or computing some value is too slow, let the user know if the given timeout elapses.
-PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT = as_float_in_env('PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT', 0.15)
+PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT = as_float_in_env('PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT', 0.50)
 
 # This timeout is used to track the time to send a message saying that the evaluation
 # is taking too long and possible mitigations.


### PR DESCRIPTION
This PR raises the timeout which notifies about a slow access to some attribute/convert to str.

I think 0.5 is a bit better than the previous default (0.15) as some popular libraries (such as pandas) are really slow there, and in general I must say I've been hitting the 0.15 limit sporadically with some unrelated conversions which usually wouldn't be a problem due to having the cpu busier.