### PR TITLE
Update pydevd

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_utils.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_utils.py
@@ -471,11 +471,17 @@ class Timer(object):
         except:
             pass
         if attrs_tab_separated:
-            return 'pydevd warning: Computing repr of %s.%s (%s) was slow (took %.2fs)\n' % (
-                attrs_tab_separated.replace('\t', '.'), attr_name, attr_type, diff)
+            return (
+                'pydevd warning: Computing repr of %s.%s (%s) was slow (took %.2fs).\n'
+                'Customize report timeout by setting the `PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT` environment variable to a higher timeout (default is: %ss)\n'
+                ) % (
+                attrs_tab_separated.replace('\t', '.'), attr_name, attr_type, diff, PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT)
         else:
-            return 'pydevd warning: Computing repr of %s (%s) was slow (took %.2fs)\n' % (
-                attr_name, attr_type, diff)
+            return (
+                'pydevd warning: Computing repr of %s (%s) was slow (took %.2fs)\n'
+                'Customize report timeout by setting the `PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT` environment variable to a higher timeout (default is: %ss)\n'
+                ) % (
+                attr_name, attr_type, diff, PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT)
 
     def report_if_getting_attr_slow(self, cls, attr_name):
         self._report_slow(self._compute_get_attr_slow, cls, attr_name)
@@ -485,7 +491,10 @@ class Timer(object):
             cls = cls.__name__
         except:
             pass
-        return 'pydevd warning: Getting attribute %s.%s was slow (took %.2fs)\n' % (cls, attr_name, diff)
+        return (
+            'pydevd warning: Getting attribute %s.%s was slow (took %.2fs)\n'
+            'Customize report timeout by setting the `PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT` environment variable to a higher timeout (default is: %ss)\n'
+            ) % (cls, attr_name, diff, PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT)
 
 
 def import_attr_from_module(import_with_attr_access):

--- a/src/debugpy/_vendored/pydevd/pydevd_tracing.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_tracing.py
@@ -49,7 +49,13 @@ def _internal_set_trace(tracing_func):
         frame = get_frame()
         if frame is not None and frame.f_back is not None:
             filename = frame.f_back.f_code.co_filename.lower()
-            if not filename.endswith('threading.py') and not filename.endswith('pydevd_tracing.py'):
+            if not filename.endswith(
+                    (
+                        'threading.py',
+                        'pydevd_tracing.py',
+                        'threadpool.py',  # This is from gevent.
+                    )
+                ):
 
                 message = \
                 '\nPYDEV DEBUGGER WARNING:' + \

--- a/src/debugpy/_vendored/pydevd/tests_python/debugger_fixtures.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/debugger_fixtures.py
@@ -487,10 +487,10 @@ def case_setup_django(debugger_runner_simple):
             version = [int(x) for x in django.get_version().split('.')][:2]
             if version == [1, 7]:
                 django_folder = 'my_django_proj_17'
-            elif version in ([2, 1], [2, 2], [3, 0], [3, 1], [3, 2], [4, 0]):
+            elif version in ([2, 1], [2, 2], [3, 0], [3, 1], [3, 2], [4, 0], [4, 1]):
                 django_folder = 'my_django_proj_21'
             else:
-                raise AssertionError('Can only check django 1.7, 2.1, 2.2, 3.0, 3.1, 3.2 and 4.0 right now. Found: %s' % (version,))
+                raise AssertionError('Can only check django 1.7 -> 4.1 right now. Found: %s' % (version,))
 
             WriterThread.DJANGO_FOLDER = django_folder
             for key, value in kwargs.items():

--- a/src/debugpy/_vendored/pydevd/tests_python/test_debugger_json.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_debugger_json.py
@@ -5425,7 +5425,7 @@ def test_debug_options(case_setup, val):
             except ImportError:
                 pass
             else:
-                gui_event_loop = 'qt5'
+                gui_event_loop = 'pyside2'
         args = dict(
             justMyCode=val,
             redirectOutput=True,  # Always redirect the output regardless of other values.

--- a/src/debugpy/_vendored/pydevd/tests_python/test_debugger_json.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_debugger_json.py
@@ -4106,6 +4106,7 @@ def test_gevent_show_paused_greenlets(case_setup, show):
 
 
 @pytest.mark.skipif(not TEST_GEVENT, reason='Gevent not installed.')
+@pytest.mark.skipif(sys.platform == 'win32', reason='tput requires Linux.')
 def test_gevent_subprocess_not_python(case_setup):
 
     def get_environ(writer):


### PR DESCRIPTION
This PR has:

- support for django 1.4 in tests
- silences a warning when using gevent (Fixes #1070)
- notifies user that customization of PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT is needed when message is shown
- other fixes in pydevd tests