### PR TITLE
Fix #1081: no need to call os.setsid() on session leader when attaching

### DIFF
--- a/src/debugpy/adapter/__main__.py
+++ b/src/debugpy/adapter/__main__.py
@@ -30,7 +30,10 @@ def main(args):
             # On POSIX, we need to leave the process group and its session, and then
             # daemonize properly by double-forking (first fork already happened when
             # this process was spawned).
-            os.setsid()
+            # NOTE: if process is already the session leader, then
+            # setsid would fail with `operation not permitted`
+            if os.getsid(os.getpid()) != os.getpid():
+                os.setsid()
             if os.fork() != 0:
                 sys.exit(0)
 


### PR DESCRIPTION
If os.setsid() raises exception when attaching to a session leader process then the debugger client won't be able to attach to the remote process anymore