### PR TITLE
Provide feedback/information in the debug console if attach to PID is slow. Fixes #1003

### DIFF
--- a/src/debugpy/adapter/servers.py
+++ b/src/debugpy/adapter/servers.py
@@ -14,7 +14,8 @@ import debugpy
 from debugpy import adapter
 from debugpy.common import json, log, messaging, sockets
 from debugpy.adapter import components
-
+import traceback
+import io
 
 access_token = None
 """Access token used to authenticate with the servers."""
@@ -471,7 +472,7 @@ def dont_wait_for_first_connection():
         _connections_changed.set()
 
 
-def inject(pid, debugpy_args):
+def inject(pid, debugpy_args, on_output):
     host, port = listener.getsockname()
 
     cmdline = [
@@ -504,20 +505,114 @@ def inject(pid, debugpy_args):
             )
         )
 
-    # We need to capture the output of the injector - otherwise it can get blocked
-    # on a write() syscall when it tries to print something.
+    # We need to capture the output of the injector - needed so that it doesn't 
+    # get blocked on a write() syscall (besides showing it to the user if it
+    # is taking longer than expected).
 
-    def capture_output():
+    output_collected = []
+    output_collected.append("--- Starting attach to pid: {0} ---\n".format(pid))
+
+    def capture(stream):
+        nonlocal output_collected
+        try:
+            while True:
+                line = stream.readline()
+                if not line:
+                    break
+                line = line.decode("utf-8", "replace")
+                output_collected.append(line)
+                log.info("Injector[PID={0}] output: {1}", pid, line.rstrip())
+            log.info("Injector[PID={0}] exited.", pid)
+        except Exception:
+            s = io.StringIO()
+            traceback.print_exc(file=s)
+            on_output("stderr", s.getvalue())
+
+    threading.Thread(
+        target=capture,
+        name=f"Injector[PID={pid}] stdout",
+        args=(injector.stdout,),
+        daemon=True,
+    ).start()
+
+    def info_on_timeout():
+        nonlocal output_collected
+        taking_longer_than_expected = False
+        initial_time = time.time()
         while True:
-            line = injector.stdout.readline()
-            if not line:
+            time.sleep(1)
+            returncode = injector.poll()
+            if returncode is not None:
+                if returncode != 0:
+                    # Something didn't work out. Let's print more info to the user.
+                    on_output(
+                        "stderr",
+                        "Attach to PID failed.\n\n",
+                    )
+                    
+                    old = output_collected
+                    output_collected = []
+                    contents = "".join(old)
+                    on_output("stderr", "".join(contents))
                 break
-            log.info("Injector[PID={0}] output:\n{1}", pid, line.rstrip())
-        log.info("Injector[PID={0}] exited.", pid)
 
-    thread = threading.Thread(
-        target=capture_output,
-        name=f"Injector[PID={pid}] output",
-    )
-    thread.daemon = True
-    thread.start()
+            elapsed = time.time() - initial_time
+            on_output(
+                "stdout", "Attaching to PID: %s (elapsed: %.2fs).\n" % (pid, elapsed)
+            )
+
+            if not taking_longer_than_expected:
+                if elapsed > 10:
+                    taking_longer_than_expected = True
+                    if sys.platform in ("linux", "linux2"):
+                        on_output(
+                            "stdout",
+                            "\nThe attach to PID is taking longer than expected.\n",
+                        )
+                        on_output(
+                            "stdout",
+                            "On Linux it's possible to customize the value of\n",
+                        )
+                        on_output(
+                            "stdout",
+                            "`PYDEVD_GDB_SCAN_SHARED_LIBRARIES` so that fewer libraries.\n",
+                        )
+                        on_output(
+                            "stdout",
+                            "are scanned when searching for the needed symbols.\n\n",
+                        )
+                        on_output(
+                            "stdout",
+                            "i.e.: set in your environment variables (and restart your editor/client\n",
+                        )
+                        on_output(
+                            "stdout",
+                            "so that it picks up the updated environment variable value):\n\n",
+                        )
+                        on_output(
+                            "stdout",
+                            "PYDEVD_GDB_SCAN_SHARED_LIBRARIES=libdl, libltdl, libc, libfreebl3\n\n",
+                        )
+                        on_output(
+                            "stdout",
+                            "-- the actual library may be different (the gdb output typically\n",
+                        )
+                        on_output(
+                            "stdout",
+                            "-- writes the libraries that will be used, so, it should be possible\n",
+                        )
+                        on_output(
+                            "stdout",
+                            "-- to test other libraries if the above doesn't work).\n\n",
+                        )
+            if taking_longer_than_expected:
+                # If taking longer than expected, start showing the actual output to the user.
+                old = output_collected
+                output_collected = []
+                contents = "".join(old)
+                if contents:
+                    on_output("stderr", contents)                
+
+    threading.Thread(
+        target=info_on_timeout, name=f"Injector[PID={pid}] info on timeout", daemon=True
+    ).start()

--- a/tests/debugpy/test_output.py
+++ b/tests/debugpy/test_output.py
@@ -32,7 +32,15 @@ def test_with_no_output(pyfile, target, run):
         session.wait_for_stop("breakpoint")
         session.request_continue()
 
-    assert not session.output("stdout")
+    output = session.output("stdout")
+    lines = []
+    for line in output.splitlines(keepends=True):
+        if not line.startswith("Attaching to PID:"):
+            lines.append(line)
+    
+    output = "".join(lines)
+    
+    assert not output
     assert not session.output("stderr")
     if session.debuggee is not None:
         assert not session.captured_stdout()
@@ -120,10 +128,17 @@ def test_redirect_output(pyfile, target, run, redirect):
         session.wait_for_stop()
         session.request_continue()
 
+    output = session.output("stdout")
+    lines = []
+    for line in output.splitlines(keepends=True):
+        if not line.startswith("Attaching to PID:"):
+            lines.append(line)
+    
+    output = "".join(lines)
     if redirect == "enabled":
-        assert session.output("stdout") == "111\n222\n333\n444\n"
+        assert output == "111\n222\n333\n444\n"
     else:
-        assert not session.output("stdout")
+        assert not output
 
 
 def test_non_ascii_output(pyfile, target, run):


### PR DESCRIPTION
Some notes:
- A message showing the elapsed time is shown whenever a second elapses.
- If it's taking too long we start showing the actual output
- On Linux besides showing the actual output we notify about customization of `PYDEVD_GDB_SCAN_SHARED_LIBRARIES`.

The debug console will now show something as (note: forced the Linux-related output to show on Windows just for the screenshot).

![image](https://user-images.githubusercontent.com/117621/195937134-4b61a553-1d75-42b6-a5e7-f837349a28b9.png)

