### PR TITLE
Fix #1148: ModuleNotFoundError: No module named 'debugpy'

### DIFF
--- a/src/debugpy/_vendored/force_pydevd.py
+++ b/src/debugpy/_vendored/force_pydevd.py
@@ -67,7 +67,7 @@ pydevd_defaults.PydevdCustomization.DEBUG_MODE = 'debugpy-dap'
 
 # This is important when pydevd attaches automatically to a subprocess. In this case, we have to
 # make sure that debugpy is properly put back in the game for users to be able to use it.
-pydevd_defaults.PydevdCustomization.PREIMPORT = '%r;%s' % (
+pydevd_defaults.PydevdCustomization.PREIMPORT = '%s;%s' % (
     os.path.dirname(os.path.dirname(debugpy.__file__)), 
     'debugpy._vendored.force_pydevd'
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py{37,38,39,310}{,-cov}
 
 [testenv]
 deps = -rtests/requirements.txt
-passenv = DEBUGPY_LOG_DIR DEBUGPY_TESTS_FULL TRAVIS
+passenv = DEBUGPY_LOG_DIR,DEBUGPY_TESTS_FULL
 setenv =
     DEBUGPY_TEST=1
 commands =


### PR DESCRIPTION
Fix #1149: UserWarning: incompatible copy of pydevd already imported

Fix formatting for sys.path entry passed to subprocesses.