### PR TITLE
Set up the proper execution environment. so that Pylance knows the cor…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,10 @@ exclude = '''
 
 [tool.pyright]
 pythonVersion = "3.7"
-include = ["src"]
+include = ["src/**", "tests/**" ]
 extraPaths = ["src/debugpy/_vendored/pydevd"]
 ignore = ["src/debugpy/_vendored/pydevd", "src/debugpy/_version.py"]
 executionEnvironments = [
-  { root = "src" }
+  { root = "src" }, { root = "." }
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,7 @@ pythonVersion = "3.7"
 include = ["src"]
 extraPaths = ["src/debugpy/_vendored/pydevd"]
 ignore = ["src/debugpy/_vendored/pydevd", "src/debugpy/_version.py"]
+executionEnvironments = [
+  { root = "src" }
+]
+


### PR DESCRIPTION
Set up the proper execution environment so that Pylance knows the correct import root for the import statement.

This will let pylance know that import root is "src", so when some feature generates "import statement", it won't include "src"

ex) rather than `import src.debugpy` it will generate `import debugpy`
