### PR TITLE
Fix #1217: Support "restart" in "terminated" event for "attach"{"listen"}

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,6 +52,7 @@
                 "host": "127.0.0.1"
             },
             "logToFile": true,
+            //"restart": true,
             "debugAdapterPath": "${workspaceFolder}/src/debugpy/adapter"
         },
         {

--- a/src/debugpy/adapter/sessions.py
+++ b/src/debugpy/adapter/sessions.py
@@ -226,8 +226,11 @@ class Session(util.Observable):
             if self.client.is_connected:
                 # Tell the client that debugging is over, but don't close the channel until it
                 # tells us to, via the "disconnect" request.
+                body = {}
+                if self.client.restart_requested:
+                    body["restart"] = True
                 try:
-                    self.client.channel.send_event("terminated")
+                    self.client.channel.send_event("terminated", body)
                 except Exception:
                     pass
 

--- a/src/debugpy/common/log.py
+++ b/src/debugpy/common/log.py
@@ -321,6 +321,7 @@ def describe_environment(header):
             prefix = " " * len(prefix)
 
     report("System paths:\n")
+    report_paths("sys.executable")
     report_paths("sys.prefix")
     report_paths("sys.base_prefix")
     report_paths("sys.real_prefix")


### PR DESCRIPTION
Request client to restart the adapter if "restart":true was specified in the debug configuration.