### PR TITLE
pydevd_attach_to_process: Use PyObject_VectorcallDict if _PyObject_FastCallDict is not available

### DIFF
--- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/common/py_settrace.hpp
+++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/common/py_settrace.hpp
@@ -132,7 +132,8 @@ int InternalSetSysTraceFunc(
     DEFINE_PROC(pyEval_CallObjectWithKeywords, PyEval_CallObjectWithKeywords*, "PyEval_CallObjectWithKeywords", 532);
 
     if(pyObject_FastCallDict == nullptr) {
-        DEFINE_PROC_NO_CHECK(pyObject_FastCallDict, _PyObject_FastCallDict*, "PyObject_VectorcallDict", 533);
+        DEFINE_PROC_NO_CHECK(pyObject_VectorcallDict, _PyObject_FastCallDict*, "PyObject_VectorcallDict", 533);
+        pyObject_FastCallDict = pyObject_VectorcallDict;
     }
                                                                                                          
     if(pyObject_FastCallDict == nullptr) {


### PR DESCRIPTION
Upon upgrading to Python 3.10, I started experiencing segfaults every time I attach debugpy. After some investigation, I noticed that `internalInitializeCustomPyEvalSetTrace->pyObject_FastCallDict` was `NULL` [here](https://github.com/microsoft/debugpy/blob/main/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/common/py_custom_pyeval_settrace_310.hpp#L30).

Turns out that in my setup the `_PyObject_FastCallDict` symbol is not found. There is a fallback to using `PyObject_VectorcallDict` instead, but the problem is that `DEFINE_PROC_NO_CHECK` creates a new variable inside the conditional scope instead updating the value of the existing `pyObject_FastCallDict` variable.