### PR TITLE
Support disabling process timeouts when set to 0

### DIFF
--- a/src/debugpy/common/__init__.py
+++ b/src/debugpy/common/__init__.py
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
 __all__ = []
 
 # The lower time bound for assuming that the process hasn't spawned successfully.
-PROCESS_SPAWN_TIMEOUT = float(os.getenv("DEBUGPY_PROCESS_SPAWN_TIMEOUT", 15))
+PROCESS_SPAWN_TIMEOUT = float(os.getenv("DEBUGPY_PROCESS_SPAWN_TIMEOUT", 15)) or None
 
 # The lower time bound for assuming that the process hasn't exited gracefully.
-PROCESS_EXIT_TIMEOUT = float(os.getenv("DEBUGPY_PROCESS_EXIT_TIMEOUT", 5))
+PROCESS_EXIT_TIMEOUT = float(os.getenv("DEBUGPY_PROCESS_EXIT_TIMEOUT", 5)) or None


### PR DESCRIPTION
Hi! Before this change, there wasn't any way to disable process timeouts, but now you can with:

```shell
export DEBUGPY_PROCESS_SPAWN_TIMEOUT=0
export DEBUGPY_PROCESS_EXIT_TIMEOUT=0
```

The one thing I noticed that may be a bit confusing though is that https://github.com/microsoft/debugpy/blob/v1.6.7/src/debugpy/adapter/clients.py#L547 still sets the timeout to `0` to force an immediate timeout, rather than disable it.