### PR TITLE
Add extensions recommendations and remove deprecated settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ ENV/
 .vs/
 .vscode/*
 !.vscode/launch.json
+!.vscode/extensions.json
 
 # PyDev
 .project

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,5 +5,4 @@
         "ms-python.flake8",
         "ms-python.black-formatter"
     ]
-
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.flake8",
+        "ms-python.black-formatter"
+    ]
+
+}

--- a/debugpy.code-workspace
+++ b/debugpy.code-workspace
@@ -5,11 +5,7 @@
         }
     ],
     "settings": {
-        "python.linting.enabled": true,
-        "python.linting.pylintEnabled": false,
-        "python.linting.flake8Enabled": true,
         "python.envFile": "${workspaceFolder}/.env",
-        "python.formatting.provider": "black",
         "files.exclude": {
             "**/*.pyc": true,
             "**/*.pyo": true,
@@ -22,6 +18,7 @@
         "python.analysis.extraPaths": [
             "src/debugpy/_vendored",
             "src/debugpy/_vendored/pydevd"
-        ]
+        ],
+        "editor.defaultFormatter": "ms-python.black-formatter"
     }
 }


### PR DESCRIPTION
The python.linting and python.formatting settings have been deprecated in the latest pre-release version of the Python extension. This PR removes these settings from debugpy repo, adds an extensions.json file to recommend flake8 and the Black formatter extension, and adds Black as the default formatter for Python. 