### PR TITLE
Unpin greenlet in tests/requirements.txt

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -17,6 +17,3 @@ django
 requests
 gevent
 flask
-
-# https://github.com/microsoft/debugpy/issues/1126
-greenlet==1.1.3


### PR DESCRIPTION
Unpinning since the original issue has been resolved upstream, and the old version doesn't work with Python 3.11.