### PR TITLE
Fix #1370: macOS wheel tag mismatched

### DIFF
--- a/.github/workflows/attach_to_process.yml
+++ b/.github/workflows/attach_to_process.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ env.PYDEVD_ATTACH_TO_PROCESS }}\*.pdb
 
   mac-binaries:
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Build macOS attach binaries on macos-11 runner.