### PR TITLE
Add ruff section to pyproject.toml

### DIFF
--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -38,13 +38,9 @@ jobs:
       # See https://github.com/astral-sh/ruff and https://beta.ruff.rs/docs/
       - script: "python3 -m pip install -U ruff"
         displayName: "Install ruff"
-
-      # We just switched to a new linter and there are a ton of errors. We need time to go through them, but we don't want the block the build.
-      # Therefore, we use continueOnError to generate a warning while there are linter errors. The build will still run.
-      # To force the step to return zero even with linter errors, add "--exit-zero" after the "check" in the command line
+        
       - script: "python3 -m ruff check --format=junit --output-file=$(Build.ArtifactStagingDirectory)/lint-ruff.xml ."
         displayName: "Run ruff"
-        continueOnError: "true"
 
       - task: "PublishTestResults@2"
         displayName: "Publish linting results"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,55 @@ executionEnvironments = [
   { root = "src" }, { root = "." }
 ]
 
+[tool.ruff]
+# Enable the pycodestyle (`E`) and Pyflakes (`F`) rules by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E", "F"]
+ignore = [
+    "E203", "E221", "E222", "E226", "E261", "E262", "E265", "E266",
+    "E401", "E402",
+    "E501",
+    "E722", "E731" 
+]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    "versioneer.py",
+    "src/debugpy/_vendored/pydevd"
+]
+per-file-ignores = {}
+
+# Same as Black.
+line-length = 88
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Assume Python 3.8
+target-version = "py38"

--- a/tests/debugpy/test_threads.py
+++ b/tests/debugpy/test_threads.py
@@ -19,7 +19,7 @@ def test_thread_count(pyfile, target, run, count):
         import sys
 
         debuggee.setup()
-        stop = False
+        stop = False # noqa: F841
 
         def worker(tid, offset):
             i = 0
@@ -35,7 +35,7 @@ def test_thread_count(pyfile, target, run, count):
                 threads.append(thread)
                 thread.start()
         print("check here")  # @bp
-        stop = True
+        stop = True  # noqa: F841
 
     with debug.Session() as session:
         with run(session, target(code_to_debug, args=[str(count)])):


### PR DESCRIPTION
Fixes #1361

I've already changed the linter from flake8 to ruff, but ruff is causing build warnings. I've fixed the ruff errors locally through migrating the ignored errors and path exclusions from the old .flake8 file, and I changed the ruff step to now fail the build if the step fails.

edit: 

Looks like some checks failed, but the Lint step is the only one I care about, and that step is passing:
https://dev.azure.com/debugpy/debugpy/_build/results?buildId=4084&view=logs&jobId=3a559e2a-952e-58d2-b8db-2e604a9266d7&j=3a559e2a-952e-58d2-b8db-2e604a9266d7&t=6f845a59-a86d-5907-2b45-02c2fb4984eb

My changes could not have caused any other failures, so I'm not worried about those other checks.
