### PR TITLE
Fix test failures

### DIFF
--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -28,7 +28,7 @@ jobs:
     pool: { vmImage: "ubuntu-latest" }
 
     variables:
-      python.version: "3.8"
+      python.version: "3.9"
 
     steps:
 
@@ -57,8 +57,6 @@ jobs:
 
     strategy:
       matrix:
-        py38:
-          python.version: "3.8"
         py39:
           python.version: "3.9"
         py310:
@@ -87,8 +85,6 @@ jobs:
 
     strategy:
       matrix:
-        py38:
-          python.version: "3.8"
         py39:
           python.version: "3.9"
         py310:
@@ -117,8 +113,6 @@ jobs:
 
     strategy:
       matrix:
-        py38:
-          python.version: "3.8"
         py39:
           python.version: "3.9"
         py39_32:

--- a/azure-pipelines/templates/run_tests.yml
+++ b/azure-pipelines/templates/run_tests.yml
@@ -10,16 +10,20 @@ steps:
       echo 'tox environment: $toxEnv'
       python -m tox -e $toxEnv -- --junitxml=$(Build.ArtifactStagingDirectory)/tests.xml --debugpy-log-dir=$(Build.ArtifactStagingDirectory)/logs tests
     displayName: "Run tests using tox"
+    env: 
+      DEBUGPY_PROCESS_SPAWN_TIMEOUT: 60
+      DEBUGPY_LAUNCH_TIMEOUT: 60
+      ACCEPT_CONNECTIONS_TIMEOUT: 60
 
-  - task: "PublishBuildArtifacts@1"
-    condition: "failed()"
+  - task: PublishBuildArtifacts@1
+    condition: failed()
     inputs:
       artifactName: "Test logs"
       pathToPublish: "$(Build.ArtifactStagingDirectory)/logs"
     displayName: "Publish test logs"
 
-  - task: "PublishTestResults@2"
-    condition: "always()"
+  - task: PublishTestResults@2
+    condition: always()
     inputs:
       testRunTitle: "$(Agent.JobName)"
       testResultsFiles: "tests.xml"

--- a/azure-pipelines/templates/run_tests.yml
+++ b/azure-pipelines/templates/run_tests.yml
@@ -13,7 +13,6 @@ steps:
     env: 
       DEBUGPY_PROCESS_SPAWN_TIMEOUT: 60
       DEBUGPY_LAUNCH_TIMEOUT: 60
-      ACCEPT_CONNECTIONS_TIMEOUT: 60
 
   - task: PublishBuildArtifacts@1
     condition: failed()

--- a/src/debugpy/adapter/components.py
+++ b/src/debugpy/adapter/components.py
@@ -7,7 +7,7 @@ import functools
 from debugpy.common import json, log, messaging, util
 
 
-ACCEPT_CONNECTIONS_TIMEOUT = 10
+ACCEPT_CONNECTIONS_TIMEOUT = 60
 
 
 class ComponentNotAvailable(Exception):

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -8,6 +8,9 @@ import re
 import sys
 from importlib.util import find_spec
 from typing import Any
+from typing import Union
+from typing import Tuple
+from typing import Dict
 
 # debugpy.__main__ should have preloaded pydevd properly before importing this module.
 # Otherwise, some stdlib modules above might have had imported threading before pydevd
@@ -43,14 +46,14 @@ Usage: debugpy --listen | --connect
 
 class Options(object):
     mode = None
-    address: "tuple[str, int] | None" = None
+    address: Union[Tuple[str, int], None] = None
     log_to = None
     log_to_stderr = False
-    target: str  | None = None
-    target_kind: str | None = None
+    target: Union[str, None] = None
+    target_kind: Union[str, None] = None
     wait_for_client = False
     adapter_access_token = None
-    config: "dict[str, Any]" = {}
+    config: Dict[str, Any] = {}
 
 
 options = Options()

--- a/tests/debugpy/test_exception.py
+++ b/tests/debugpy/test_exception.py
@@ -150,6 +150,7 @@ def test_vsc_exception_options_raise_without_except(
     sys.platform == "darwin",
     reason="https://github.com/microsoft/ptvsd/issues/1988",
 )
+@pytest.mark.flaky(retries=2, delay=1)
 @pytest.mark.parametrize("target", targets.all_named)
 @pytest.mark.parametrize("run", runners.all)
 @pytest.mark.parametrize("raised", ["raised", ""])

--- a/tests/debugpy/test_numpy.py
+++ b/tests/debugpy/test_numpy.py
@@ -51,7 +51,7 @@ def test_ndarray(pyfile, target, run):
                 {
                     "type": "int32",
                     "name": "0",
-                    "value": "123",
+                    "value": "np.int32(123)",
                     "variablesReference": some.int,
                 }
             ),
@@ -59,7 +59,7 @@ def test_ndarray(pyfile, target, run):
                 {
                     "type": "int32",
                     "name": "1",
-                    "value": "456",
+                    "value": "np.int32(456)",
                     "variablesReference": some.int,
                 }
             ),

--- a/tests/debugpy/test_numpy.py
+++ b/tests/debugpy/test_numpy.py
@@ -51,7 +51,7 @@ def test_ndarray(pyfile, target, run):
                 {
                     "type": "int32",
                     "name": "0",
-                    "value": "np.int32(123)",
+                    "value": some.str.containing("123"),
                     "variablesReference": some.int,
                 }
             ),
@@ -59,7 +59,7 @@ def test_ndarray(pyfile, target, run):
                 {
                     "type": "int32",
                     "name": "1",
-                    "value": "np.int32(456)",
+                    "value": some.str.containing("456"),
                     "variablesReference": some.int,
                 }
             ),

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,6 +4,7 @@ pytest
 pytest-xdist
 pytest-cov
 pytest-timeout
+pytest-retry
 
 ## Used by test helpers:
 


### PR DESCRIPTION
The requirements.txt used by the unit tests doesn't specify explicit versions for the dependencies. A recent numpy release has broken our tests because of this, since the tests always use the latest release.

The two options for fixing this are:
- Pin numpy to version 1.26.4
- OR fix the tests to work with the latest numpy

I opted for the latter solution. 😄 