### PR TITLE
Add parsing args from environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ The tests are run concurrently, and the default number of workers is 8. You can 
 
 ### Running tests without tox
 
-While tox is the recommended way to run the test suite, pytest can also be invoked directly from the root of the repository. This requires packages in tests/test_requirements.txt to be installed first.
+While tox is the recommended way to run the test suite, pytest can also be invoked directly from the root of the repository. This requires packages in tests/requirements.txt to be installed first.
 
 ## Using modified debugpy in Visual Studio Code
 To test integration between debugpy and Visual Studio Code, the latter can be directed to use a custom version of debugpy in lieu of the one bundled with the Python extension. This is done by specifying `"debugAdapterPath"` in `launch.json` - it must point at the root directory of the *package*, which is `src/debugpy` inside the repository:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,12 +76,17 @@ On Linux or macOS:
 
 You can run all tests in a single file using a specified python version, like this:
 ```
-...\debugpy> py -m tox --develop -e py312 -- -n0 ".\tests\debugpy\server\test_cli.py"
+...\debugpy> py -m tox --develop -e py312 -- ".\tests\debugpy\server\test_cli.py"
 ```
 
 You can also specify a single test, like this:
 ```
-...\debugpy> py -m tox --develop -e py312 -- -n0 ".\tests\debugpy\server\test_cli.py::test_duplicate_switch"
+...\debugpy> py -m tox --develop -e py312 -- ".\tests\debugpy\server\test_cli.py::test_duplicate_switch"
+```
+
+The tests are run concurrently, and the default number of workers is 8. You can force a single worker by using the `-n0` flag, like this:
+```
+...\debugpy> py -m tox --develop -e py312 -- -n0 ".\tests\debugpy\server\test_cli.py"
 ```
 
 ### Running tests without tox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,16 @@ On Linux or macOS:
 .../debugpy$ python3 -m tox -e py27,py37 --develop
 ```
 
+You can run all tests in a single file using a specified python version, like this:
+```
+...\debugpy> py -m tox --develop -e py312 -- -n0 ".\tests\debugpy\server\test_cli.py"
+```
+
+You can also specify a single test, like this:
+```
+...\debugpy> py -m tox --develop -e py312 -- -n0 ".\tests\debugpy\server\test_cli.py::test_duplicate_switch"
+```
+
 ### Running tests without tox
 
 While tox is the recommended way to run the test suite, pytest can also be invoked directly from the root of the repository. This requires packages in tests/test_requirements.txt to be installed first.

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -7,10 +7,7 @@ import os
 import re
 import sys
 from importlib.util import find_spec
-from typing import Any
-from typing import Union
-from typing import Tuple
-from typing import Dict
+from typing import Any, Union, Tuple, Dict
 
 # debugpy.__main__ should have preloaded pydevd properly before importing this module.
 # Otherwise, some stdlib modules above might have had imported threading before pydevd
@@ -193,48 +190,22 @@ switches = [
 ]
 # fmt: on
 
-
-def consume_argv():
-    while len(sys.argv) >= 2:
-        value = sys.argv[1]
-        del sys.argv[1]
+# Consume all the args from a given list
+def consume_args(args: list):
+    while len(args) >= 2:
+        value = args[1]
+        del args[1]
         yield value
 
+# Parse the args from the command line, then from the environment.
+# Args from the environment are only used if they are not already set from the command line.
+def parse_args():
 
-def parse_argv():
+    # keep track of the switches we've seen so far
     seen = set()
-    it = consume_argv()
 
-    while True:
-        try:
-            arg = next(it)
-        except StopIteration:
-            raise ValueError("missing target: " + TARGET)
-
-        switch = arg
-        if not switch.startswith("-"):
-            switch = ""
-        for pattern, placeholder, action in switches:
-            if re.match("^(" + pattern + ")$", switch):
-                break
-        else:
-            raise ValueError("unrecognized switch " + switch)
-
-        if switch in seen:
-            raise ValueError("duplicate switch " + switch)
-        else:
-            seen.add(switch)
-
-        try:
-            action(arg, it)
-        except StopIteration:
-            assert placeholder is not None
-            raise ValueError("{0}: missing {1}".format(switch, placeholder))
-        except Exception as exc:
-            raise ValueError("invalid {0} {1}: {2}".format(switch, placeholder, exc))
-
-        if options.target is not None:
-            break
+    parse_args_from_command_line(seen)
+    parse_args_from_environment(seen)
 
     if options.mode is None:
         raise ValueError("either --listen or --connect is required")
@@ -247,6 +218,75 @@ def parse_argv():
     assert options.target_kind is not None
     assert options.address is not None
 
+def parse_args_from_command_line(seen: set):
+    parse_args_helper(sys.argv, seen)
+
+def parse_args_from_environment(seenFromCommandLine: set):
+    args = os.getenv("DEBUGPY_EXTRA_ARGV")
+    if (not args):
+        return
+
+    argsList = args.split()
+    seenFromEnvironment = set()
+    parse_args_helper(argsList, seenFromCommandLine, seenFromEnvironment, True)
+
+def parse_args_helper(args: list, seenFromCommandLine: set, seenFromEnvironment: set = None, isFromEnvironment=False):
+    it = consume_args(args)
+
+    while True:
+        try:
+            arg = next(it)
+        except StopIteration:
+            # If we get here, we've processed all the arguments.
+
+            # If we're parsing from the command line, we should never get here, so this is an error
+            # (because we break from the loop as soon as the target is set).
+            if (not isFromEnvironment):
+                raise ValueError("missing target: " + TARGET)
+            # Otherwise, we're done parsing from the environment, so make sure the target is set
+            else:
+                if (options.target is None):
+                    raise ValueError("missing target from environment: " + TARGET)
+
+        switch = arg
+        if not switch.startswith("-"):
+            switch = ""
+        for pattern, placeholder, action in switches:
+            if re.match("^(" + pattern + ")$", switch):
+                break
+        else:
+            raise ValueError("unrecognized switch " + switch)
+
+        # if we're parsing from the command line, and we've already seen the switch on the command line, this is an error
+        if (not isFromEnvironment and switch in seenFromCommandLine):
+            raise ValueError("duplicate switch on command line" + switch)
+        # if we're parsing from the environment, and we've already seen the switch in the environment, this is an error
+        elif (isFromEnvironment and switch in seenFromEnvironment):
+            raise ValueError("duplicate switch from environment" + switch)
+        # if we're parsing from the environment, and we've already seen the switch on the command line, skip it, since command line takes precedence
+        elif (isFromEnvironment and switch in seenFromCommandLine):
+            continue
+        # otherwise, the switch is new, so add it to the appropriate set
+        else:
+            if (isFromEnvironment):
+                seenFromEnvironment.add(switch)
+            else:
+                seenFromCommandLine.add(switch)
+
+        # process the switch, running the corresponding action
+        try:
+            action(arg, it)
+        except StopIteration:
+            assert placeholder is not None
+            raise ValueError("{0}: missing {1}".format(switch, placeholder))
+        except Exception as exc:
+            raise ValueError("invalid {0} {1}: {2}".format(switch, placeholder, exc))
+
+        # If we're parsing the command line, we're done after we've processed the target
+        # Otherwise, we need to keep parsing until all args are consumed, since the target may be set from the command line
+        # already, but there might be additional args in the environment that we want to process.
+        if (not isFromEnvironment and options.target is not None):
+            break
 
 def start_debugging(argv_0):
     # We need to set up sys.argv[0] before invoking either listen() or connect(),
@@ -411,7 +451,7 @@ attach_pid_injected.attach(setup);
 def main():
     original_argv = list(sys.argv)
     try:
-        parse_argv()
+        parse_args()
     except Exception as exc:
         print(str(HELP) + str("\nError: ") + str(exc), file=sys.stderr)
         sys.exit(2)

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -245,7 +245,7 @@ def parse_args_from_environment(seenFromCommandLine: set):
     seenFromEnvironment = set()
     parse_args_helper(argsList, seenFromCommandLine, seenFromEnvironment, True)
 
-def parse_args_helper(args: list, seenFromCommandLine: set, seenFromEnvironment: set = None, isFromEnvironment=False):
+def parse_args_helper(args: list, seenFromCommandLine: set, seenFromEnvironment: set = set(), isFromEnvironment=False):
     iterator = consume_args(args)
 
     while True:

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -219,7 +219,7 @@ def parse_args():
     parse_args_from_environment(seen)
 
     # if the target is not set, or is empty, this is an error
-    if options.target is None or not options.target.strip():
+    if options.target is None or options.target == "":
         raise ValueError("missing target: " + TARGET)
 
     if options.mode is None:

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -204,7 +204,7 @@ def consume_argv():
 # Consume all the args from a given list
 def consume_args(args: list):
     if (args is sys.argv):
-        return consume_argv()
+        yield from consume_argv()
     
     while len(args) >= 1:
         value = args[0]

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -219,7 +219,7 @@ def parse_args():
     seen = set()
 
     parse_args_from_command_line(seen)
-    #parse_args_from_environment(seen)
+    parse_args_from_environment(seen)
 
     log.debug("options:")
     log.debug(options.__dict__)

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -202,11 +202,11 @@ def consume_argv():
 def consume_args(args: list):
     if (args is sys.argv):
         yield from consume_argv()
-    
-    while len(args) >= 1:
-        value = args[0]
-        del args[0]
-        yield value
+    else:
+        while len(args) >= 1:
+            value = args[0]
+            del args[0]
+            yield value
 
 # Parse the args from the command line, then from the environment.
 # Args from the environment are only used if they are not already set from the command line.

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -190,8 +190,18 @@ switches = [
 ]
 # fmt: on
 
+# Consume all the args from argv
+def consume_argv():
+    while len(sys.argv) >= 2:
+        value = sys.argv[1]
+        del sys.argv[1]
+        yield value
+
 # Consume all the args from a given list
 def consume_args(args: list):
+    if (args == sys.argv):
+        return consume_argv()
+    
     while len(args) >= 1:
         value = args[0]
         del args[0]
@@ -205,7 +215,7 @@ def parse_args():
     seen = set()
 
     parse_args_from_command_line(seen)
-    parse_args_from_environment(seen)
+    #parse_args_from_environment(seen)
 
     #print("options:", file=sys.stderr)
     #print(options.__dict__, file=sys.stderr)
@@ -225,7 +235,7 @@ def parse_args():
     assert options.address is not None
 
 def parse_args_from_command_line(seen: set):
-    parse_args_helper(sys.argv[1:], seen)
+    parse_args_helper(sys.argv, seen)
 
 def parse_args_from_environment(seenFromCommandLine: set):
     args = os.environ.get("DEBUGPY_EXTRA_ARGV")

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -192,9 +192,9 @@ switches = [
 
 # Consume all the args from a given list
 def consume_args(args: list):
-    while len(args) >= 2:
-        value = args[1]
-        del args[1]
+    while len(args) >= 1:
+        value = args[0]
+        del args[0]
         yield value
 
 # Parse the args from the command line, then from the environment.
@@ -206,6 +206,9 @@ def parse_args():
 
     parse_args_from_command_line(seen)
     parse_args_from_environment(seen)
+
+    #print("options:", file=sys.stderr)
+    #print(options.__dict__, file=sys.stderr)
 
     if options.target is None:
         raise ValueError("missing target: " + TARGET)
@@ -222,14 +225,18 @@ def parse_args():
     assert options.address is not None
 
 def parse_args_from_command_line(seen: set):
-    parse_args_helper(sys.argv, seen)
+    parse_args_helper(sys.argv[1:], seen)
 
 def parse_args_from_environment(seenFromCommandLine: set):
-    args = os.getenv("DEBUGPY_EXTRA_ARGV")
+    args = os.environ.get("DEBUGPY_EXTRA_ARGV")
     if (not args):
         return
 
     argsList = args.split()
+
+    #print("args:", file=sys.stderr)
+    #print(*argsList, file=sys.stderr)
+
     seenFromEnvironment = set()
     parse_args_helper(argsList, seenFromCommandLine, seenFromEnvironment, True)
 

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -203,7 +203,7 @@ def consume_args(args: list):
     if (args is sys.argv):
         yield from consume_argv()
     else:
-        while len(args) >= 1:
+        while args:
             value = args[0]
             del args[0]
             yield value

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -242,9 +242,6 @@ def parse_args_from_environment(seenFromCommandLine: set):
 
     argsList = args.split()
 
-    #print("args:", file=sys.stderr)
-    #print(*argsList, file=sys.stderr)
-
     seenFromEnvironment = set()
     parse_args_helper(argsList, seenFromCommandLine, seenFromEnvironment, True)
 

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -218,7 +218,8 @@ def parse_args():
     parse_args_from_command_line(seen)
     parse_args_from_environment(seen)
 
-    if options.target is None:
+    # if the target is not set, or is empty, this is an error
+    if options.target is None or not options.target.strip():
         raise ValueError("missing target: " + TARGET)
 
     if options.mode is None:
@@ -228,7 +229,6 @@ def parse_args():
     if options.target_kind == "pid" and options.wait_for_client:
         raise ValueError("--pid does not support --wait-for-client")
 
-    assert options.target is not None
     assert options.target_kind is not None
     assert options.address is not None
 

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -158,7 +158,11 @@ def set_target(kind: str, parser=(lambda x: x), positional=False):
                     import locale
 
                     target = target.decode(locale.getpreferredencoding(False))
+
         options.target = target
+
+        log.debug("kind: " + kind)
+        log.debug("target: " + target)
 
     return do
 
@@ -199,7 +203,7 @@ def consume_argv():
 
 # Consume all the args from a given list
 def consume_args(args: list):
-    if (args == sys.argv):
+    if (args is sys.argv):
         return consume_argv()
     
     while len(args) >= 1:
@@ -217,8 +221,8 @@ def parse_args():
     parse_args_from_command_line(seen)
     #parse_args_from_environment(seen)
 
-    #print("options:", file=sys.stderr)
-    #print(options.__dict__, file=sys.stderr)
+    log.debug("options:")
+    log.debug(options.__dict__)
 
     if options.target is None:
         raise ValueError("missing target: " + TARGET)
@@ -253,7 +257,12 @@ def parse_args_from_environment(seenFromCommandLine: set):
 def parse_args_helper(args: list, seenFromCommandLine: set, seenFromEnvironment: set = None, isFromEnvironment=False):
     iterator = consume_args(args)
 
-    for arg in iterator:
+    while True:
+        try:
+            arg = next(iterator)
+        except StopIteration:
+            break
+
         switch = arg
         if not switch.startswith("-"):
             switch = ""

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -161,9 +161,6 @@ def set_target(kind: str, parser=(lambda x: x), positional=False):
 
         options.target = target
 
-        log.debug("kind: " + kind)
-        log.debug("target: " + target)
-
     return do
 
 
@@ -220,9 +217,6 @@ def parse_args():
 
     parse_args_from_command_line(seen)
     parse_args_from_environment(seen)
-
-    log.debug("options:")
-    log.debug(options.__dict__)
 
     if options.target is None:
         raise ValueError("missing target: " + TARGET)

--- a/tests/debugpy/server/test_cli.py
+++ b/tests/debugpy/server/test_cli.py
@@ -180,7 +180,7 @@ def test_address_required(cli):
 
 def test_missing_target(cli):
     with pytest.raises(ValueError) as ex:
-        cli(["--listen", "8888", "-m", ""])
+        cli(["--listen", "8888"])
     
     assert "missing target" in str(ex.value)
 

--- a/tests/debugpy/server/test_cli.py
+++ b/tests/debugpy/server/test_cli.py
@@ -21,7 +21,7 @@ def cli(pyfile):
         from debugpy.server import cli
 
         try:
-            cli.parse_argv()
+            cli.parse_args()
         except Exception as exc:
             os.write(1, pickle.dumps(exc))
             sys.exit(1)

--- a/tests/debugpy/server/test_cli.py
+++ b/tests/debugpy/server/test_cli.py
@@ -154,3 +154,15 @@ def test_address_required(cli):
         cli(["-m", "spam"])
     
     assert "either --listen or --connect is required" in str(ex.value)
+
+def test_missing_target(cli):
+    with pytest.raises(ValueError) as ex:
+        cli(["--listen", "8888"])
+    
+    assert "missing target" in str(ex.value)
+
+def test_duplicate_switch(cli):
+    with pytest.raises(ValueError) as ex:
+        cli(["--listen", "8888", "--listen", "9999", "spam.py"])
+    
+    assert "duplicate switch on command line: --listen" in str(ex.value)

--- a/tests/debugpy/server/test_cli.py
+++ b/tests/debugpy/server/test_cli.py
@@ -136,15 +136,21 @@ def test_configure_subProcess(cli, value):
 
 
 def test_unsupported_switch(cli):
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError) as ex:
         cli(["--listen", "8888", "--xyz", "123", "spam.py"])
+    
+    assert "unrecognized switch --xyz" in str(ex.value)
 
 
 def test_unsupported_configure(cli):
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError) as ex:
         cli(["--connect", "127.0.0.1:8888", "--configure-xyz", "123", "spam.py"])
+    
+    assert "unknown property 'xyz'" in str(ex.value)
 
 
 def test_address_required(cli):
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError) as ex:
         cli(["-m", "spam"])
+    
+    assert "either --listen or --connect is required" in str(ex.value)

--- a/tests/debugpy/server/test_cli.py
+++ b/tests/debugpy/server/test_cli.py
@@ -73,11 +73,16 @@ def cli(pyfile):
 
 
 # Test a combination of command line switches
-@pytest.mark.parametrize("target_kind", ["file", "module", "code"])
-@pytest.mark.parametrize("mode", ["listen", "connect"])
-@pytest.mark.parametrize("address", ["8888", "localhost:8888"])
-@pytest.mark.parametrize("wait_for_client", ["", "wait_for_client"])
-@pytest.mark.parametrize("script_args", ["", "script_args"])
+#@pytest.mark.parametrize("target_kind", ["file", "module", "code"])
+#@pytest.mark.parametrize("mode", ["listen", "connect"])
+#@pytest.mark.parametrize("address", ["8888", "localhost:8888"])
+#@pytest.mark.parametrize("wait_for_client", ["", "wait_for_client"])
+#@pytest.mark.parametrize("script_args", ["", "script_args"])
+@pytest.mark.parametrize("target_kind", ["file"])
+@pytest.mark.parametrize("mode", ["listen"])
+@pytest.mark.parametrize("address", ["8888"])
+@pytest.mark.parametrize("wait_for_client", ["wait_for_client"])
+@pytest.mark.parametrize("script_args", ["script_args"])
 def test_targets(cli, target_kind, mode, address, wait_for_client, script_args):
     expected_options = {
         "mode": mode,

--- a/tests/debugpy/server/test_cli.py
+++ b/tests/debugpy/server/test_cli.py
@@ -224,5 +224,5 @@ def test_script_args(cli):
     args = ["--listen", "8888", "spam.py", "arg1", "arg2"]
     argv, options = cli(args)
 
-    assert argv == ["--listen", "8888", "spam.py", "arg1", "arg2"]
+    assert argv == ["arg1", "arg2"]
     assert options["target"] == "spam.py"

--- a/tests/debugpy/server/test_cli.py
+++ b/tests/debugpy/server/test_cli.py
@@ -73,16 +73,11 @@ def cli(pyfile):
 
 
 # Test a combination of command line switches
-#@pytest.mark.parametrize("target_kind", ["file", "module", "code"])
-#@pytest.mark.parametrize("mode", ["listen", "connect"])
-#@pytest.mark.parametrize("address", ["8888", "localhost:8888"])
-#@pytest.mark.parametrize("wait_for_client", ["", "wait_for_client"])
-#@pytest.mark.parametrize("script_args", ["", "script_args"])
-@pytest.mark.parametrize("target_kind", ["file"])
-@pytest.mark.parametrize("mode", ["listen"])
-@pytest.mark.parametrize("address", ["8888"])
-@pytest.mark.parametrize("wait_for_client", ["wait_for_client"])
-@pytest.mark.parametrize("script_args", ["script_args"])
+@pytest.mark.parametrize("target_kind", ["file", "module", "code"])
+@pytest.mark.parametrize("mode", ["listen", "connect"])
+@pytest.mark.parametrize("address", ["8888", "localhost:8888"])
+@pytest.mark.parametrize("wait_for_client", ["", "wait_for_client"])
+@pytest.mark.parametrize("script_args", ["", "script_args"])
 def test_targets(cli, target_kind, mode, address, wait_for_client, script_args):
     expected_options = {
         "mode": mode,

--- a/tests/debugpy/server/test_cli.py
+++ b/tests/debugpy/server/test_cli.py
@@ -180,7 +180,7 @@ def test_address_required(cli):
 
 def test_missing_target(cli):
     with pytest.raises(ValueError) as ex:
-        cli(["--listen", "8888"])
+        cli(["--listen", "8888", "-m", ""])
     
     assert "missing target" in str(ex.value)
 


### PR DESCRIPTION
Fixes #1612

- Added reading args from the environment. Command line args always take precedence.
- Added unit tests for environment args

Testing was done in several ways:

1. I added multiple unit tests for the new code that reads from the environment, as well as made sure that existing tests were passing.
2. I debugged a python file locally, pointing vscode at my local debugpy source, using the following launch.json config:

```json
{
      "name": "Python Debugger: Current File WITH ARGS",
      "type": "debugpy",
      "request": "launch",
      "program": "${file}",
      "console": "integratedTerminal",
      "debugAdapterPath": "E:/repos/github/debugpy/src/debugpy/adapter",
      "args" : ["--msg", "Hello World"]
    },
```
I verified that these extra args were passed to the file being run and that breakpoints could be hit. I also verified that this worked with no args.

3. I opened a command prompt and starting debugpy in listen mode:

`python E:\repos\github\debugpy\src\debugpy --listen 5678 --wait-for-client "C:\Users\advolker\OneDrive - Microsoft\Desktop\pythonTest\infiniteLoop.py"`

Then I attached through vscode using the following launch.json config:

```json
    {
      "name": "Attach",
      "type": "python",
      "request": "attach",
      "connect": {
        "port": 5678,
      }  
```

Breakpoints worked just fine.

4. I did the same test as above, but I set the options `--listen 5678` and `--wait-for-client` in the environment before running debugpy, like this:

`set DEBUGPY_EXTRA_ARGV=--listen 5678 --wait-for-client`

Then I started debugpy from the same command prompt with only the target specified. The other options were read from the environment:

`python E:\repos\github\debugpy\src\debugpy "C:\Users\advolker\OneDrive - Microsoft\Desktop\pythonTest\infiniteLoop.py"`

Then I attached through vscode in the same way as the previous step. Breakpoints worked just fine.