### PR TITLE
Add debugpy entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -195,5 +195,7 @@ if __name__ == "__main__":
         ext_modules=ExtModules(),
         has_ext_modules=lambda: True,
         cmdclass=cmds,
+        # allow the user to call "debugpy" instead of "python -m debugpy"
+        entry_points={"console_scripts": ["debugpy = debugpy.server.cli:main"]},
         **extras
     )

--- a/src/debugpy/__main__.py
+++ b/src/debugpy/__main__.py
@@ -3,7 +3,6 @@
 # for license information.
 
 import sys
-import os
 
 if __name__ == "__main__":
 
@@ -29,10 +28,17 @@ if __name__ == "__main__":
     # -----
     #
     # In the third case, running 'python -m debugpy' will not work because the module is not installed
-    # in any environment. Running 'python <path_to_debugpy>' will work, just like the second case. 
-    # But running 'debugpy' will not work because even though the entry point is defined, 
-    # that path is not in sys.path, so 'import debugpy' will fail. So just like in the second case, 
-    # we need to modify sys.path[0].
+    # in any environment. Running 'python <install_dir>/debugpy' will work, just like the second case. 
+    # But running the entry point will not work because python doesn't know where to find the debugpy module.
+    #
+    # In this case, no changes to sys.path are required. You just have to do the following before calling
+    # the entry point:
+    #   1. Add <install_dir> to PYTHONPATH.
+    #       On Windows, this is set PYTHONPATH=%PYTHONPATH%;<install_dir>
+    #   2. Add <install_dir>/bin to PATH. (OPTIONAL)
+    #       On Windows, this is set PATH=%PATH%;<install_dir>\bin
+    #   3. Run the entry point from a command prompt
+    #       On Windows, this is <install_dir>\bin\debugpy.exe, or just 'debugpy' if you did the previous step.
     #
     # -----
     #
@@ -55,15 +61,8 @@ if __name__ == "__main__":
     # or its submodules will resolve accordingly.
     if "debugpy" not in sys.modules:
 
-        # if the user has specified a path to the debugpy module, replace sys.path[0] with
-        # the specified path. Otherwise, replace sys.path[0] with the parent directory of debugpy/
-        debugpy_path = os.environ.get("DEBUGPY_PATH")
-        if (debugpy_path is not None):    
-            sys.path[0] = debugpy_path
-        else:
-            # Do not use dirname() to walk up - this can be a relative path, e.g. ".".
-            sys.path[0] = sys.path[0] + "/../"
-        
+        # Do not use dirname() to walk up - this can be a relative path, e.g. ".".
+        sys.path[0] = sys.path[0] + "/../"
         import debugpy  # noqa
         del sys.path[0]
 

--- a/src/debugpy/__main__.py
+++ b/src/debugpy/__main__.py
@@ -3,34 +3,67 @@
 # for license information.
 
 import sys
-
+import os
 
 if __name__ == "__main__":
-    # debugpy can also be invoked directly rather than via -m. In this case, the first
-    # entry on sys.path is the one added automatically by Python for the directory
-    # containing this file. This means that import debugpy will not work, since we need
-    # the parent directory of debugpy/ to be in sys.path, rather than debugpy/ itself.
+
+    # There are three ways to run debugpy:
     #
-    # The other issue is that many other absolute imports will break, because they
-    # will be resolved relative to debugpy/ - e.g. `import debugger` will then try
+    # 1. Installed as a module in the current environment (python -m debugpy ...)
+    # 2. Run as a script from source code (python <repo_root>/src/debugpy ...)
+    # 3. Installed as a module in a random directory
+    #
+    # -----
+    #
+    # In the first case, no extra work is needed. Importing debugpy will work as expected.
+    # Also, running 'debugpy' instead of 'python -m debugpy' will work because of the entry point
+    # defined in setup.py.
+    #
+    # -----
+    #
+    # In the second case, sys.path[0] is the one added automatically by Python for the directory 
+    # containing this file. 'import debugpy' will not work since we need the parent directory 
+    # of debugpy/ to be in sys.path, rather than debugpy/ itself. So we need to modify sys.path[0].
+    # Running 'debugpy' will not work because the entry point is not defined in this case.
+    #
+    # -----
+    #
+    # In the third case, running 'python -m debugpy' will not work because the module is not installed
+    # in any environment. Running 'python <path_to_debugpy>' will work, just like the second case. 
+    # But running 'debugpy' will not work because even though the entry point is defined, 
+    # that path is not in sys.path, so 'import debugpy' will fail. So just like in the second case, 
+    # we need to modify sys.path[0].
+    #
+    # -----
+    #
+    # If we modify sys.path, 'import debugpy' will work, but it will break other imports
+    # because they will be resolved relative to debugpy/ - e.g. `import debugger` will try
     # to import debugpy/debugger.py.
     #
-    # To fix both, we need to replace the automatically added entry such that it points
-    # at parent directory of debugpy/ instead of debugpy/ itself, import debugpy with that
-    # in sys.path, and then remove the first entry entry altogether, so that it doesn't
-    # affect any further imports we might do. For example, suppose the user did:
+    # To fix both problems, we need to do the following steps:
+    # 1. Modify sys.path[0] to point at the parent directory of debugpy/ instead of debugpy/ itself.
+    # 2. Import debugpy.
+    # 3. Remove sys.path[0] so that it doesn't affect future imports. 
+    # 
+    # For example, suppose the user did:
     #
     #   python /foo/bar/debugpy ...
     #
-    # At the beginning of this script, sys.path will contain "/foo/bar/debugpy" as the
-    # first entry. What we want is to replace it with "/foo/bar', then import debugpy
-    # with that in effect, and then remove the replaced entry before any more
-    # code runs. The imported debugpy module will remain in sys.modules, and thus all
-    # future imports of it or its submodules will resolve accordingly.
+    # At the beginning of this script, sys.path[0] will contain "/foo/bar/debugpy".
+    # We want to replace it with "/foo/bar', then 'import debugpy', then remove the replaced entry.
+    # The imported debugpy module will remain in sys.modules, and thus all future imports of it 
+    # or its submodules will resolve accordingly.
     if "debugpy" not in sys.modules:
-        # Do not use dirname() to walk up - this can be a relative path, e.g. ".".
-        sys.path[0] = sys.path[0] + "/../"
-        import debugpy  # noqa
+
+        # if the user has specified a path to the debugpy module, replace sys.path[0] with
+        # the specified path. Otherwise, replace sys.path[0] with the parent directory of debugpy/
+        debugpy_path = os.environ.get("DEBUGPY_PATH")
+        if (debugpy_path is not None):    
+            sys.path[0] = debugpy_path
+        else:
+            # Do not use dirname() to walk up - this can be a relative path, e.g. ".".
+            sys.path[0] = sys.path[0] + "/../"
+            import debugpy  # noqa
 
         del sys.path[0]
 

--- a/src/debugpy/__main__.py
+++ b/src/debugpy/__main__.py
@@ -63,8 +63,8 @@ if __name__ == "__main__":
         else:
             # Do not use dirname() to walk up - this can be a relative path, e.g. ".".
             sys.path[0] = sys.path[0] + "/../"
-            import debugpy  # noqa
-
+        
+        import debugpy  # noqa
         del sys.path[0]
 
     from debugpy.server import cli


### PR DESCRIPTION
Fixes #1613

- Added an entry point as documented at https://setuptools.pypa.io/en/latest/userguide/entry_point.html

## Testing ##

### Scenario 1 - Package is installed in active environment ###

#### Windows ####
1. I ran the internal debugpy pipeline, pointing the resources at my `add_entry_point` branch instead of main.
1. I downloaded the `debugpy-1.8.2+12.g853cc05f-cp311-cp311-win_amd64.whl` from https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9942339&view=artifacts&pathAsName=false&type=publishedArtifacts
1. I installed the wheel by running `python -m pip install --no-index --find-links . debugpy`
1. I ran `python -m debugpy -V` to verify that it installed correctly.
1. Then I ran `debugpy -V` to verify that the entry point exists. The output was the same as the previous step, which proves the entry point works.
1. I also ran `debugpy --listen 5678 "C:\Users\advolker\OneDrive - Microsoft\Desktop\pythonTest\infiniteLoop.py"` and it ran correctly, which proves args are being passed along.

#### Linux (WSL) ####
1. Install WSL on a devbox using the docs at https://learn.microsoft.com/en-us/windows/wsl/install
2. Install python 3.10 using `sudo apt install python3 python3-pip`
3. Download the wheel from https://devdiv.visualstudio.com/_apis/resources/Containers/18694131/dist?itemPath=dist%2Fdebugpy-1.8.2%2B15.gaaab9932-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
4. Install the wheel using `python3 -m pip install --no-index --find-links . debugpy`
5. Add the bin directory to path like this: `export PATH=$PATH:/home/advolker/.local/bin`
6. Run `debugpy -V` and see that it works
7. I also ran `debugpy --listen 5678 ./infiniteLoop.py` and it worked.

### Scenario 2 - Package is installed in random directory ###

#### Windows ####

1. I ran the internal debugpy pipeline, pointing the resources at my `add_entry_point` branch instead of main.
1. I downloaded the `debugpy-1.8.2%2B15.gaaab9932-cp311-cp311-win_amd64.whl` from https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9950165&view=artifacts&pathAsName=false&type=publishedArtifacts
1. I installed the wheel by running `python -m pip install -t .\temp --no-index --find-links . debugpy`
1. I added `C:\Users\advolker\OneDrive - Microsoft\Desktop\temp\bin` to `PATH`, like this: `SET PATH=%PATH%;C:\Users\advolker\OneDrive - Microsoft\Desktop\temp\bin`
    1. This is the directory that contains the entry point (debugpy.exe on Windows)
1. I added `C:\Users\advolker\OneDrive - Microsoft\Desktop\temp` to `PYTHONPATH`, like this: `SET PYTHONPATH=%PYTHONPATH%;C:\Users\advolker\OneDrive - Microsoft\Desktop\temp`
    1. This is the root directory that the package was installed to 
1. I ran `debugpy -V` to verify that the entry point works.
1. I also ran `debugpy --listen 5678 "C:\Users\advolker\OneDrive - Microsoft\Desktop\pythonTest\infiniteLoop.py"` and it ran correctly.

#### Linux (WSL) ####

1. Install WSL on a devbox using the docs at https://learn.microsoft.com/en-us/windows/wsl/install
2. Install python 3.10 using `sudo apt install python3 python3-pip`
3. Download the wheel from https://devdiv.visualstudio.com/_apis/resources/Containers/18694131/dist?itemPath=dist%2Fdebugpy-1.8.2%2B15.gaaab9932-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
4. Install the wheel using `python3 -m pip install -t ./temp --no-index --find-links . debugpy`
5. Add the bin directory to path like this: `export PATH=$PATH:/home/advolker/temp/bin`
6. Add the install directory to pythonpath, like this: `export PYTHONPATH=$PYTHONPATH:/home/advolker/temp`
7. Run `debugpy -V` and see that it works
8. I also ran `debugpy --listen 5678 ./infiniteLoop.py` and it worked.