### PR TITLE
to display lentgh/shape, addressing #1525, #1191, #4244, etc.

### DIFF
--- a/src/debugpy/_vendored/pydevd/pydevd_plugins/extensions/types/pydevd_plugin_sized_str.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_plugins/extensions/types/pydevd_plugin_sized_str.py
@@ -1,0 +1,20 @@
+from _pydevd_bundle.pydevd_extension_api import StrPresentationProvider
+from .pydevd_helpers import find_mod_attr
+
+
+class SizedShapeStr:
+    '''Displays the size of an Sized object before displaying its value.
+    '''
+    def can_provide(self, type_object, type_name):
+        sized_obj = find_mod_attr('collections.abc', 'Sized')
+        return sized_obj is not None and issubclass(type_object, sized_obj)
+
+    def get_str(self, val):
+        if hasattr(val, 'shape'):
+            return f'shape: {val.shape}, value: {val}'
+        return f'len: {len(val)}, value: {val}'
+
+import sys
+
+if not sys.platform.startswith("java"):
+    StrPresentationProvider.register(SizedShapeStr)


### PR DESCRIPTION
Displays the size of an Sized variable before displaying its value, such as np.ndrray, torch.Tensor. Can benefit ML/AI programming, as well as other programming that works heavily on large collections.