### PR TITLE
In 3.12 findlinestarts seems to return None for line more often

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
@@ -83,7 +83,8 @@ else:
             # bodies of nested class and function definitions, as they have their
             # own objects.
             for _, lineno in dis.findlinestarts(code):
-                yield lineno
+                if lineno is not None:
+                    yield lineno
 
             # For nested class and function definitions, their respective code objects
             # are constants referenced by this object.

--- a/src/debugpy/_vendored/pydevd/_pydevd_frame_eval/pydevd_modify_bytecode.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_frame_eval/pydevd_modify_bytecode.py
@@ -59,7 +59,8 @@ def _get_code_line_info(code_obj):
     last_line = None
 
     for offset, line in dis.findlinestarts(code_obj):
-        line_to_offset[line] = offset
+        if line is not None and offset is not None:
+            line_to_offset[line] = offset
 
     if line_to_offset:
         first_line = min(line_to_offset)

--- a/src/debugpy/_vendored/pydevd/pydevd.py
+++ b/src/debugpy/_vendored/pydevd/pydevd.py
@@ -791,10 +791,10 @@ class PyDB(object):
                     max_line = -1
                     min_line = sys.maxsize
                     for _, line in dis.findlinestarts(code_obj):
-                        if line > max_line:
+                        if line is not None and line > max_line:
                             max_line = line
 
-                        if line < min_line:
+                        if line is not None and line < min_line:
                             min_line = line
 
                     try_except_infos = [x for x in try_except_infos if min_line <= x.try_line <= max_line]


### PR DESCRIPTION
Fixes https://github.com/microsoft/debugpy/issues/1720