### PR TITLE
Build pydevd binaries before running tests

### DIFF
--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -83,7 +83,7 @@ jobs:
       - task: DeleteFiles@1
         displayName: Clean up old binaries
         inputs:
-          SourceFolder: $(Build.SourcesDirectory)/debugpy/$(PYDEVD_ATTACH_TO_PROCESS)
+          SourceFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
           Contents: |
             *.so
 
@@ -91,7 +91,7 @@ jobs:
       - task: Bash@3
         displayName: Build pydevd binaries
         inputs:
-          filepath: $(Build.SourcesDirectory)/debugpy/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_linux.sh
+          filepath: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_linux.sh
 
       - template: "templates/run_tests.yml"
 
@@ -127,7 +127,7 @@ jobs:
       - task: DeleteFiles@1
         displayName: Clean up old binaries
         inputs:
-          SourceFolder: $(Build.SourcesDirectory)/debugpy/$(PYDEVD_ATTACH_TO_PROCESS)
+          SourceFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
           Contents: |
             *.so
 
@@ -135,7 +135,7 @@ jobs:
       - task: Bash@3
         displayName: Build pydevd binaries
         inputs:
-          filepath: $(Build.SourcesDirectory)/debugpy/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_mac.sh
+          filepath: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_mac.sh
 
       - template: "templates/run_tests.yml"
 
@@ -168,7 +168,7 @@ jobs:
       - task: DeleteFiles@1
         displayName: Clean up old binaries
         inputs:
-          SourceFolder: $(Build.SourcesDirectory)\debugpy\$(PYDEVD_ATTACH_TO_PROCESS)
+          SourceFolder: $(Build.SourcesDirectory)\$(PYDEVD_ATTACH_TO_PROCESS)
           Contents: |
             *.exe
             *.dll
@@ -178,7 +178,7 @@ jobs:
       - task: BatchScript@1
         displayName: Build pydevd binaries
         inputs:
-          filename: $(Build.SourcesDirectory)\debugpy\$(PYDEVD_ATTACH_TO_PROCESS)\windows\compile_windows.bat
-          workingFolder: $(Build.SourcesDirectory)\debugpy\$(PYDEVD_ATTACH_TO_PROCESS)\windows      
+          filename: $(Build.SourcesDirectory)\$(PYDEVD_ATTACH_TO_PROCESS)\windows\compile_windows.bat
+          workingFolder: $(Build.SourcesDirectory)\$(PYDEVD_ATTACH_TO_PROCESS)\windows      
 
       - template: "templates/run_tests.yml"

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -19,6 +19,7 @@ pr:
 
 variables:
   architecture: "x64"
+  PYDEVD_ATTACH_TO_PROCESS: src/debugpy/_vendored/pydevd/pydevd_attach_to_process
 
 jobs:
 
@@ -78,6 +79,20 @@ jobs:
 
       - template: "templates/use_python.yml"
 
+      # Clean up old binaries
+      - task: DeleteFiles@1
+        displayName: Clean up old binaries
+        inputs:
+          SourceFolder: $(Build.SourcesDirectory)/debugpy/$(PYDEVD_ATTACH_TO_PROCESS)
+          Contents: |
+            *.so
+
+      # Build pydevd binaries
+      - task: Bash@3
+        displayName: Build pydevd binaries
+        inputs:
+          filepath: $(Build.SourcesDirectory)/debugpy/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_linux.sh
+
       - template: "templates/run_tests.yml"
 
   - job: "Test_MacOS"
@@ -108,6 +123,20 @@ jobs:
       - script: "python -m ensurepip --user"
         displayName: "Bootstrap pip"
 
+      # Clean up old binaries
+      - task: DeleteFiles@1
+        displayName: Clean up old binaries
+        inputs:
+          SourceFolder: $(Build.SourcesDirectory)/debugpy/$(PYDEVD_ATTACH_TO_PROCESS)
+          Contents: |
+            *.so
+
+      # Build pydevd binaries
+      - task: Bash@3
+        displayName: Build pydevd binaries
+        inputs:
+          filepath: $(Build.SourcesDirectory)/debugpy/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_mac.sh
+
       - template: "templates/run_tests.yml"
 
   - job: "Test_Windows"
@@ -135,4 +164,21 @@ jobs:
 
       - template: "templates/use_python.yml"
       
+      # Clean up old binaries
+      - task: DeleteFiles@1
+        displayName: Clean up old binaries
+        inputs:
+          SourceFolder: $(Build.SourcesDirectory)\debugpy\$(PYDEVD_ATTACH_TO_PROCESS)
+          Contents: |
+            *.exe
+            *.dll
+            *.pdb
+      
+      # Build pydevd binaries
+      - task: BatchScript@1
+        displayName: Build pydevd binaries
+        inputs:
+          filename: $(Build.SourcesDirectory)\debugpy\$(PYDEVD_ATTACH_TO_PROCESS)\windows\compile_windows.bat
+          workingFolder: $(Build.SourcesDirectory)\debugpy\$(PYDEVD_ATTACH_TO_PROCESS)\windows      
+
       - template: "templates/run_tests.yml"


### PR DESCRIPTION
We're removing these binaries from the repo and adding a .gitignore entry for them, since we want to build them ourselves. So we need to make sure we build them before running tests, because the attach tests will fail if those binaries don't exist.