### PR TITLE
Build and publish pydevd binaries

### DIFF
--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -18,7 +18,7 @@ pr:
   drafts: false
 
 variables:
-  architecture: "x64"
+  architecture: x64
   PYDEVD_ATTACH_TO_PROCESS: src/debugpy/_vendored/pydevd/pydevd_attach_to_process
 
 stages:

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -15,222 +15,233 @@ pr:
     include:
       - main
       - release/*
-  drafts: "false"
+  drafts: false
 
 variables:
   architecture: "x64"
   PYDEVD_ATTACH_TO_PROCESS: src/debugpy/_vendored/pydevd/pydevd_attach_to_process
 
-jobs:
+stages:
 
-  - job: "Lint"
-    timeoutInMinutes: "5"
-    displayName: "Lint"
-    pool: { vmImage: "ubuntu-latest" }
+  - stage: Lint
+    jobs:
+      - job: Lint
+        timeoutInMinutes: 5
 
-    variables:
-      python.version: "3.9"
+        pool:
+          vmImage: ubuntu-latest
 
-    steps:
+        variables:
+          python.version: "3.9"
 
-      - template: "templates/use_python.yml"
+        steps:
 
-      # Install and run ruff
-      # See https://github.com/astral-sh/ruff and https://beta.ruff.rs/docs/
-      - script: "python3 -m pip install -U ruff"
-        displayName: "Install ruff"
-        
-      - script: "python3 -m ruff check --output-format=junit --output-file=$(Build.ArtifactStagingDirectory)/lint-ruff.xml ."
-        displayName: "Run ruff"
+          - template: templates/use_python.yml
 
-      - task: "PublishTestResults@2"
-        displayName: "Publish linting results"
-        inputs:
-          testRunTitle: "$(Agent.JobName)"
-          testResultsFiles: "lint-*.xml"
-          searchFolder: "$(Build.ArtifactStagingDirectory)"
-        condition: "always()"
+          # Install and run ruff
+          # See https://github.com/astral-sh/ruff and https://beta.ruff.rs/docs/
+          - script: python3 -m pip install -U ruff
+            displayName: Install ruff
+          
+          # Run linter
+          - script: python3 -m ruff check --output-format=junit --output-file=$(Build.ArtifactStagingDirectory)/lint-ruff.xml .
+            displayName: Run ruff
 
-  - job: pydevd_binaries
-    displayName: Build pydevd binaries
+          # Publish results, even on failure
+          - task: PublishTestResults@2
+            displayName: Publish linting results
+            inputs:
+              testRunTitle: $(Agent.JobName)
+              testResultsFiles: lint-*.xml
+              searchFolder: $(Build.ArtifactStagingDirectory)
+            condition: always()
 
-    strategy:
-      matrix:
-        windows:
-          image: windows-latest
-          contents: |
-            *.exe
-            *.dll
-            *.pdb
-          script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/windows/compile_windows.bat
-          workingDirectory: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/windows
-        mac:
-          image: macOS-latest
-          contents: |
-            *.dylib
-          script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_mac.sh
-          workingDirectory: $(System.DefaultWorkingDirectory)
-        linux:
-          image: ubuntu-latest
-          contents: |
-            *.so
-          script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_linux.sh
-          workingDirectory: $(System.DefaultWorkingDirectory)
-        
-    pool:
-      vmImage: $(image)
-
-    steps:
-
-      # Clean up old binaries
-      - task: DeleteFiles@1
-        displayName: Clean up old binaries
-        inputs:
-          SourceFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
-          Contents: $(contents)
-
-      # Build pydevd binaries
-      - script: $(script)
+  - stage: Pydevd
+    jobs:
+      - job: pydevd_binaries
         displayName: Build pydevd binaries
-        workingDirectory: $(workingDirectory)
+
+        strategy:
+          matrix:
+            windows:
+              image: windows-latest
+              contents: |
+                *.exe
+                *.dll
+                *.pdb
+              script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/windows/compile_windows.bat
+              workingDirectory: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/windows
+            mac:
+              image: macOS-latest
+              contents: |
+                *.dylib
+              script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_mac.sh
+              workingDirectory: $(System.DefaultWorkingDirectory)
+            linux:
+              image: ubuntu-latest
+              contents: |
+                *.so
+              script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_linux.sh
+              workingDirectory: $(System.DefaultWorkingDirectory)
+            
+        pool:
+          vmImage: $(image)
+
+        steps:
+
+          # Clean up old binaries
+          - task: DeleteFiles@1
+            displayName: Clean up old binaries
+            inputs:
+              SourceFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+              Contents: $(contents)
+
+          # Build pydevd binaries
+          - script: $(script)
+            displayName: Build pydevd binaries
+            workingDirectory: $(workingDirectory)
+        
+          # copy pydevd binaries
+          - task: CopyFiles@2
+            displayName: Copy pydevd binaries
+            inputs:
+              SourceFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+              Contents: $(contents)
+              TargetFolder: $(Build.ArtifactStagingDirectory)
+        
+          # Publish pydevd binaries
+          - task: PublishBuildArtifacts@1
+            displayName: Publish pydevd binaries
+            inputs:
+              artifactName: pydevd binaries
+              pathToPublish: $(Build.ArtifactStagingDirectory)
     
-      # copy pydevd binaries
-      - task: CopyFiles@2
-        displayName: Copy pydevd binaries
-        inputs:
-          SourceFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
-          Contents: $(contents)
-          TargetFolder: $(Build.ArtifactStagingDirectory)
-    
-      # Publish pydevd binaries
-      - task: PublishBuildArtifacts@1
-        displayName: Publish pydevd binaries
-        inputs:
-          artifactName: pydevd binaries
-          pathToPublish: $(Build.ArtifactStagingDirectory)
-    
-  - job: "Test_Linux"
-    timeoutInMinutes: "30"
-    displayName: "Tests - Linux"
-    pool: { vmImage: "ubuntu-latest" }
-    dependsOn: pydevd_binaries
+  - stage: Test
+    dependsOn: Pydevd
+    jobs:
 
-    strategy:
-      matrix:
-        py39:
-          python.version: "3.9"
-        py310:
-          python.version: "3.10"
-        py311:
-          python.version: "3.11"
-        py312:
-          python.version: "3.12"
-        py313:
-          python.version: "3.13"
+    - job: Tests_Linux
+      displayName: Tests - Linux
+      timeoutInMinutes: 30
+      pool:
+        vmImage: ubuntu-latest
 
-    steps:
+      strategy:
+        matrix:
+          py39:
+            python.version: 3.9
+          py310:
+            python.version: 3.10
+          py311:
+            python.version: 3.11
+          py312:
+            python.version: 3.12
+          py313:
+            python.version: 3.13
 
-      - script: |
-          sudo apt-get update
-          sudo apt-get --yes install gdb
-          sudo sysctl kernel.yama.ptrace_scope=0
-        displayName: "Setup gdb"
+      steps:
 
-      - template: "templates/use_python.yml"
+        - script: |
+            sudo apt-get update
+            sudo apt-get --yes install gdb
+            sudo sysctl kernel.yama.ptrace_scope=0
+          displayName: Setup gdb
 
-      # download pydevd binaries
-      - download: current
-        displayName: Download pydevd binaries
-        artifact: pydevd binaries
+        - template: templates/use_python.yml
 
-      # copy pydevd binaries
-      - task: CopyFiles@2
-        displayName: Copy pydevd binaries
-        inputs:
-          SourceFolder: $(Pipeline.Workspace)/pydevd binaries
-          TargetFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+        # download pydevd binaries
+        - download: current
+          displayName: Download pydevd binaries
+          artifact: pydevd binaries
 
-      - template: "templates/run_tests.yml"
+        # copy pydevd binaries
+        - task: CopyFiles@2
+          displayName: Copy pydevd binaries
+          inputs:
+            SourceFolder: $(Pipeline.Workspace)/pydevd binaries
+            TargetFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
 
-  - job: "Test_MacOS"
-    timeoutInMinutes: "30"
-    displayName: "Tests - macOS"
-    pool: { vmImage: "macOS-latest" }
-    dependsOn: pydevd_binaries
+        - template: templates/run_tests.yml
 
-    strategy:
-      matrix:
-        py39:
-          python.version: "3.9"
-        py310:
-          python.version: "3.10"
-        py311:
-          python.version: "3.11"
-        py312:
-          python.version: "3.12"
-        py313:
-          python.version: "3.13"
+    - job: Tests_Mac
+      timeoutInMinutes: 30
+      displayName: Tests - macOS
+      pool:
+        vmImage: macOS-latest
 
-    steps:
+      strategy:
+        matrix:
+          py39:
+            python.version: 3.9
+          py310:
+            python.version: 3.10
+          py311:
+            python.version: 3.11
+          py312:
+            python.version: 3.12
+          py313:
+            python.version: 3.13
 
-      - script: "ulimit -Sn 8192"
-        displayName: "Increase file descriptor limit"
+      steps:
 
-      - template: "templates/use_python.yml"
+        - script: ulimit -Sn 8192
+          displayName: Increase file descriptor limit
 
-      - script: "python -m ensurepip --user"
-        displayName: "Bootstrap pip"
+        - template: templates/use_python.yml
 
-      # download pydevd binaries
-      - download: current
-        displayName: Download pydevd binaries
-        artifact: pydevd binaries
+        - script: python -m ensurepip --user
+          displayName: Bootstrap pip
 
-      # copy pydevd binaries
-      - task: CopyFiles@2
-        displayName: Copy pydevd binaries
-        inputs:
-          SourceFolder: $(Pipeline.Workspace)/pydevd binaries
-          TargetFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+        # download pydevd binaries
+        - download: current
+          displayName: Download pydevd binaries
+          artifact: pydevd binaries
 
-      - template: "templates/run_tests.yml"
+        # copy pydevd binaries
+        - task: CopyFiles@2
+          displayName: Copy pydevd binaries
+          inputs:
+            SourceFolder: $(Pipeline.Workspace)/pydevd binaries
+            TargetFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
 
-  - job: "Test_Windows"
-    timeoutInMinutes: "40"
-    displayName: "Tests - Windows"
-    pool: { vmImage: "windows-latest" }
-    dependsOn: pydevd_binaries
+        - template: templates/run_tests.yml
 
-    strategy:
-      matrix:
-        py39:
-          python.version: "3.9"
-        py39_32:
-          python.version: "3.9"
-          architecture: "x86"
-        py310:
-          python.version: "3.10"
-        py311:
-          python.version: "3.11"
-        py312:
-          python.version: "3.12"
-        py313:
-          python.version: "3.13"
+    - job: Test_Windows
+      timeoutInMinutes: 40
+      displayName: Tests - Windows
+      pool:
+        vmImage: windows-latest
 
-    steps:
+      strategy:
+        matrix:
+          py39:
+            python.version: 3.9
+          py39_32:
+            python.version: 3.9
+            architecture: x86
+          py310:
+            python.version: 3.10
+          py311:
+            python.version: 3.11
+          py312:
+            python.version: 3.12
+          py313:
+            python.version: 3.13
 
-      - template: "templates/use_python.yml"
-      
-      # download pydevd binaries
-      - download: current
-        displayName: Download pydevd binaries
-        artifact: pydevd binaries
+      steps:
 
-      # copy pydevd binaries
-      - task: CopyFiles@2
-        displayName: Copy pydevd binaries
-        inputs:
-          SourceFolder: $(Pipeline.Workspace)/pydevd binaries
-          TargetFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+        - template: templates/use_python.yml
+        
+        # download pydevd binaries
+        - download: current
+          displayName: Download pydevd binaries
+          artifact: pydevd binaries
 
-      - template: "templates/run_tests.yml"
+        # copy pydevd binaries
+        - task: CopyFiles@2
+          displayName: Copy pydevd binaries
+          inputs:
+            SourceFolder: $(Pipeline.Workspace)/pydevd binaries
+            TargetFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+
+        - template: templates/run_tests.yml

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -139,12 +139,16 @@ jobs:
       - template: "templates/use_python.yml"
 
       # download pydevd binaries
-      - task: DownloadBuildArtifacts@1
+      - download: current
         displayName: Download pydevd binaries
+        artifact: pydevd binaries
+
+      # copy pydevd binaries
+      - task: CopyFiles@2
+        displayName: Copy pydevd binaries
         inputs:
-          buildType: current
-          artifactName: pydevd binaries
-          downloadPath: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+          SourceFolder: $(Pipeline.Workspace)/pydevd binaries
+          TargetFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
 
       - template: "templates/run_tests.yml"
 
@@ -178,12 +182,16 @@ jobs:
         displayName: "Bootstrap pip"
 
       # download pydevd binaries
-      - task: DownloadBuildArtifacts@1
+      - download: current
         displayName: Download pydevd binaries
+        artifact: pydevd binaries
+
+      # copy pydevd binaries
+      - task: CopyFiles@2
+        displayName: Copy pydevd binaries
         inputs:
-          buildType: current
-          artifactName: pydevd binaries
-          downloadPath: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+          SourceFolder: $(Pipeline.Workspace)/pydevd binaries
+          TargetFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
 
       - template: "templates/run_tests.yml"
 
@@ -214,11 +222,15 @@ jobs:
       - template: "templates/use_python.yml"
       
       # download pydevd binaries
-      - task: DownloadBuildArtifacts@1
+      - download: current
         displayName: Download pydevd binaries
+        artifact: pydevd binaries
+
+      # copy pydevd binaries
+      - task: CopyFiles@2
+        displayName: Copy pydevd binaries
         inputs:
-          buildType: current
-          artifactName: pydevd binaries
-          downloadPath: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+          SourceFolder: $(Pipeline.Workspace)/pydevd binaries
+          TargetFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
 
       - template: "templates/run_tests.yml"

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -51,10 +51,69 @@ jobs:
           searchFolder: "$(Build.ArtifactStagingDirectory)"
         condition: "always()"
 
+  - job: pydevd_binaries
+    displayName: Build pydevd binaries
+
+    strategy:
+      matrix:
+        windows:
+          image: windows-latest
+          contents: |
+            *.exe
+            *.dll
+            *.pdb
+          script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/windows/compile_windows.bat
+          workingDirectory: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/windows
+        mac:
+          image: macOS-latest
+          contents: |
+            *.dylib
+          script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_mac.sh
+          workingDirectory: $(System.DefaultWorkingDirectory)
+        linux:
+          image: ubuntu-latest
+          contents: |
+            *.so
+          script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_linux.sh
+          workingDirectory: $(System.DefaultWorkingDirectory)
+        
+    pool:
+      vmImage: $(image)
+
+    steps:
+
+      # Clean up old binaries
+      - task: DeleteFiles@1
+        displayName: Clean up old binaries
+        inputs:
+          SourceFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+          Contents: $(contents)
+
+      # Build pydevd binaries
+      - script: $(script)
+        displayName: Build pydevd binaries
+        workingDirectory: $(workingDirectory)
+    
+      # copy pydevd binaries
+      - task: CopyFiles@2
+        displayName: Copy pydevd binaries
+        inputs:
+          SourceFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
+          Contents: $(contents)
+          TargetFolder: $(Build.ArtifactStagingDirectory)
+    
+      # Publish pydevd binaries
+      - task: PublishBuildArtifacts@1
+        displayName: Publish pydevd binaries
+        inputs:
+          artifactName: pydevd binaries
+          pathToPublish: $(Build.ArtifactStagingDirectory)
+    
   - job: "Test_Linux"
     timeoutInMinutes: "30"
     displayName: "Tests - Linux"
     pool: { vmImage: "ubuntu-latest" }
+    dependsOn: pydevd_binaries
 
     strategy:
       matrix:
@@ -79,19 +138,13 @@ jobs:
 
       - template: "templates/use_python.yml"
 
-      # Clean up old binaries
-      - task: DeleteFiles@1
-        displayName: Clean up old binaries
+      # download pydevd binaries
+      - task: DownloadBuildArtifacts@1
+        displayName: Download pydevd binaries
         inputs:
-          SourceFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
-          Contents: |
-            *.so
-
-      # Build pydevd binaries
-      - task: Bash@3
-        displayName: Build pydevd binaries
-        inputs:
-          filepath: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_linux.sh
+          buildType: current
+          artifactName: pydevd binaries
+          downloadPath: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
 
       - template: "templates/run_tests.yml"
 
@@ -99,6 +152,7 @@ jobs:
     timeoutInMinutes: "30"
     displayName: "Tests - macOS"
     pool: { vmImage: "macOS-latest" }
+    dependsOn: pydevd_binaries
 
     strategy:
       matrix:
@@ -123,19 +177,13 @@ jobs:
       - script: "python -m ensurepip --user"
         displayName: "Bootstrap pip"
 
-      # Clean up old binaries
-      - task: DeleteFiles@1
-        displayName: Clean up old binaries
+      # download pydevd binaries
+      - task: DownloadBuildArtifacts@1
+        displayName: Download pydevd binaries
         inputs:
-          SourceFolder: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
-          Contents: |
-            *.so
-
-      # Build pydevd binaries
-      - task: Bash@3
-        displayName: Build pydevd binaries
-        inputs:
-          filepath: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_mac.sh
+          buildType: current
+          artifactName: pydevd binaries
+          downloadPath: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
 
       - template: "templates/run_tests.yml"
 
@@ -143,6 +191,7 @@ jobs:
     timeoutInMinutes: "40"
     displayName: "Tests - Windows"
     pool: { vmImage: "windows-latest" }
+    dependsOn: pydevd_binaries
 
     strategy:
       matrix:
@@ -164,21 +213,12 @@ jobs:
 
       - template: "templates/use_python.yml"
       
-      # Clean up old binaries
-      - task: DeleteFiles@1
-        displayName: Clean up old binaries
+      # download pydevd binaries
+      - task: DownloadBuildArtifacts@1
+        displayName: Download pydevd binaries
         inputs:
-          SourceFolder: $(Build.SourcesDirectory)\$(PYDEVD_ATTACH_TO_PROCESS)
-          Contents: |
-            *.exe
-            *.dll
-            *.pdb
-      
-      # Build pydevd binaries
-      - task: BatchScript@1
-        displayName: Build pydevd binaries
-        inputs:
-          filename: $(Build.SourcesDirectory)\$(PYDEVD_ATTACH_TO_PROCESS)\windows\compile_windows.bat
-          workingFolder: $(Build.SourcesDirectory)\$(PYDEVD_ATTACH_TO_PROCESS)\windows      
+          buildType: current
+          artifactName: pydevd binaries
+          downloadPath: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)
 
       - template: "templates/run_tests.yml"

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -58,12 +58,12 @@ stages:
 
   - stage: Pydevd
     jobs:
-      - job: pydevd_binaries
-        displayName: Build pydevd binaries
+      - job: Build
+        displayName: Build
 
         strategy:
           matrix:
-            windows:
+            Windows:
               image: windows-latest
               contents: |
                 *.exe
@@ -71,13 +71,13 @@ stages:
                 *.pdb
               script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/windows/compile_windows.bat
               workingDirectory: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/windows
-            mac:
+            macOS:
               image: macOS-latest
               contents: |
                 *.dylib
               script: $(Build.SourcesDirectory)/$(PYDEVD_ATTACH_TO_PROCESS)/linux_and_mac/compile_mac.sh
               workingDirectory: $(System.DefaultWorkingDirectory)
-            linux:
+            Linux:
               image: ubuntu-latest
               contents: |
                 *.so

--- a/azure-pipelines/templates/run_tests.yml
+++ b/azure-pipelines/templates/run_tests.yml
@@ -1,6 +1,6 @@
 steps:
-  - script: "python -m pip install tox"
-    displayName: "Setup Python packages"
+  - script: python -m pip install tox
+    displayName: Setup Python packages
 
   - pwsh: |
       $toxEnv = '$(python.version)'
@@ -9,22 +9,23 @@ steps:
       }
       echo 'tox environment: $toxEnv'
       python -m tox -e $toxEnv -- --junitxml=$(Build.ArtifactStagingDirectory)/tests.xml --debugpy-log-dir=$(Build.ArtifactStagingDirectory)/logs tests
-    displayName: "Run tests using tox"
+    displayName: Run tests using tox
     env: 
       DEBUGPY_PROCESS_SPAWN_TIMEOUT: 60
       DEBUGPY_LAUNCH_TIMEOUT: 60
 
   - task: PublishBuildArtifacts@1
-    condition: failed()
+    displayName: Publish test logs
     inputs:
-      artifactName: "Test logs"
-      pathToPublish: "$(Build.ArtifactStagingDirectory)/logs"
-    displayName: "Publish test logs"
+      artifactName: Test logs
+      pathToPublish: $(Build.ArtifactStagingDirectory)/logs
+    condition: failed()
 
   - task: PublishTestResults@2
-    condition: always()
+    displayName: Publish test results
     inputs:
-      testRunTitle: "$(Agent.JobName)"
-      testResultsFiles: "tests.xml"
-      searchFolder: "$(Build.ArtifactStagingDirectory)"
-    displayName: "Publish test results"
+      testRunTitle: $(Agent.JobName)
+      testResultsFiles: tests.xml
+      searchFolder: $(Build.ArtifactStagingDirectory)
+    condition: always()
+

--- a/azure-pipelines/templates/use_python.yml
+++ b/azure-pipelines/templates/use_python.yml
@@ -1,6 +1,6 @@
 steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: "$(python.version)"
-      architecture: "$(architecture)"
-    displayName: "Use Python $(python.version) $(architecture)"
+      versionSpec: $(python.version)
+      architecture: $(architecture)
+    displayName: Use Python $(python.version) $(architecture)


### PR DESCRIPTION
- Build pydevd binaries and publish them as pipeline artifacts
- Download published artifacts in test jobs and copy them to the appropriate location, before tests run
- Move lint and pydevd to their own stages for a cleaner build
- Yaml cleanup

I ran the test pipeline manually pointing at this pr branch, the run is at https://dev.azure.com/debugpy/debugpy/_build/results?buildId=4332&view=results

