### PR TITLE
Properly update pydevd._settrace.called

### DIFF
--- a/src/debugpy/server/api.py
+++ b/src/debugpy/server/api.py
@@ -42,7 +42,7 @@ def _settrace(*args, **kwargs):
     # The stdin in notification is not acted upon in debugpy, so, disable it.
     kwargs.setdefault("notify_stdin", False)
     try:
-        return pydevd.settrace(*args, **kwargs)
+        pydevd.settrace(*args, **kwargs)
     except Exception:
         raise
     else:

--- a/src/debugpy/server/api.py
+++ b/src/debugpy/server/api.py
@@ -45,11 +45,9 @@ def _settrace(*args, **kwargs):
         pydevd.settrace(*args, **kwargs)
     except Exception:
         raise
-    else:
-        _settrace.called = True
 
 
-_settrace.called = False
+_listen.called = False
 
 
 def ensure_logging():
@@ -78,9 +76,6 @@ def log_to(path):
 
 
 def configure(properties=None, **kwargs):
-    if _settrace.called:
-        raise RuntimeError("debug adapter is already running")
-
     ensure_logging()
     log.debug("configure{0!r}", (properties, kwargs))
 
@@ -104,9 +99,6 @@ def configure(properties=None, **kwargs):
 
 def _starts_debugging(func):
     def debug(address, **kwargs):
-        if _settrace.called:
-            raise RuntimeError("this process already has a debug adapter")
-
         try:
             _, port = address
         except Exception:
@@ -116,7 +108,7 @@ def _starts_debugging(func):
             port.__index__()  # ensure it's int-like
         except Exception:
             raise ValueError("expected port or (host, port)")
-        if not (0 <= port < 2 ** 16):
+        if not (0 <= port < 2**16):
             raise ValueError("invalid port number")
 
         ensure_logging()
@@ -150,10 +142,14 @@ def listen(address, settrace_kwargs, in_process_debug_adapter=False):
     # Errors below are logged with level="info", because the caller might be catching
     # and handling exceptions, and we don't want to spam their stderr unnecessarily.
 
+    if _listen.called:
+        # Multiple calls to listen() cause the debuggee to hang
+        raise RuntimeError("debugpy.listen() has already been called on this process")
+
     if in_process_debug_adapter:
         host, port = address
         log.info("Listening: pydevd without debugpy adapter: {0}:{1}", host, port)
-        settrace_kwargs['patch_multiprocessing'] = False
+        settrace_kwargs["patch_multiprocessing"] = False
         _settrace(
             host=host,
             port=port,
@@ -218,7 +214,10 @@ def listen(address, settrace_kwargs, in_process_debug_adapter=False):
         try:
             global _adapter_process
             _adapter_process = subprocess.Popen(
-                adapter_args, close_fds=True, creationflags=creationflags, env=python_env
+                adapter_args,
+                close_fds=True,
+                creationflags=creationflags,
+                env=python_env,
             )
             if os.name == "posix":
                 # It's going to fork again to daemonize, so we need to wait on it to
@@ -288,6 +287,7 @@ def listen(address, settrace_kwargs, in_process_debug_adapter=False):
         **settrace_kwargs
     )
     log.info("pydevd is connected to adapter at {0}:{1}", server_host, server_port)
+    _listen.called = True
     return client_host, client_port
 
 

--- a/src/debugpy/server/api.py
+++ b/src/debugpy/server/api.py
@@ -47,9 +47,6 @@ def _settrace(*args, **kwargs):
         raise
 
 
-_listen.called = False
-
-
 def ensure_logging():
     """Starts logging to log.log_dir, if it hasn't already been done."""
     if ensure_logging.ensured:
@@ -142,7 +139,7 @@ def listen(address, settrace_kwargs, in_process_debug_adapter=False):
     # Errors below are logged with level="info", because the caller might be catching
     # and handling exceptions, and we don't want to spam their stderr unnecessarily.
 
-    if _listen.called:
+    if listen.called:
         # Multiple calls to listen() cause the debuggee to hang
         raise RuntimeError("debugpy.listen() has already been called on this process")
 
@@ -287,8 +284,10 @@ def listen(address, settrace_kwargs, in_process_debug_adapter=False):
         **settrace_kwargs
     )
     log.info("pydevd is connected to adapter at {0}:{1}", server_host, server_port)
-    _listen.called = True
+    listen.called = True
     return client_host, client_port
+
+listen.called = False
 
 
 @_starts_debugging

--- a/tests/debugpy/test_attach.py
+++ b/tests/debugpy/test_attach.py
@@ -108,7 +108,6 @@ def test_multiple_listen_raises_exception(pyfile, target):
         import debuggee
         import debugpy
         import sys
-        import time
 
         from debuggee import backchannel
 
@@ -125,7 +124,7 @@ def test_multiple_listen_raises_exception(pyfile, target):
 
     host, port = runners.attach_connect.host, runners.attach_connect.port
     with debug.Session() as session:
-        backchannel = session.open_backchannel()
+        session.open_backchannel()
         session.spawn_debuggee(
             [
                 code_to_debug,


### PR DESCRIPTION
`api._settrace.called` is intended to confirm that a process had been traced before. However, returning in a `try` block prevents the subsequent `else` block from executing, so `api._settrace` was not updating this flag.

This change just removes the return. `api._settrace` will still return `None`, as `pydevd.settrace` was returning `None` before.