### PR TITLE
Make sure attach binaries are built before running tox

### DIFF
--- a/build_attach_binaries.py
+++ b/build_attach_binaries.py
@@ -8,11 +8,10 @@ def build_pydevd_binaries(force: bool):
     # Attempt to find where Visual Studio is installed if we're running on Windows.
     if os.name == "nt":
         try:
-            import pyMSVC
-            env = pyMSVC.Environment()
-            c_info = pyMSVC.VisualCInfo(env)
-            info = pyMSVC.VisualStudioInfo(env, c_info)
-            os.environ["FORCE_PYDEVD_VC_VARS"] = os.path.join(info.install_directory, "VC", "Auxiliary", "Build", "vcvars64.bat")
+            import vswhere
+            install_path = vswhere.get_latest_path(prerelease=True)
+            if install_path is not None:
+                os.environ["FORCE_PYDEVD_VC_VARS"] = os.path.join(install_path, "VC", "Auxiliary", "Build", "vcvars64.bat")
         except ImportError:
             pass
 

--- a/build_attach_binaries.py
+++ b/build_attach_binaries.py
@@ -1,0 +1,40 @@
+# This script is used for building the pydevd binaries
+import argparse
+import os
+
+def build_pydevd_binaries(force: bool):
+    os.environ["PYDEVD_USE_CYTHON"] = "yes"
+
+    # Attempt to find where Visual Studio is installed if we're running on Windows.
+    if os.name == "nt":
+        try:
+            import pyMSVC
+            env = pyMSVC.Environment()
+            c_info = pyMSVC.VisualCInfo(env)
+            info = pyMSVC.VisualStudioInfo(env, c_info)
+            os.environ["FORCE_PYDEVD_VC_VARS"] = os.path.join(info.install_directory, "VC", "Auxiliary", "Build", "vcvars64.bat")
+        except ImportError:
+            pass
+
+    # Run the pydevd build command.
+    pydevd_root = os.path.join(os.path.dirname(__file__), "src", "debugpy", "_vendored", "pydevd")
+
+    # Run the appropriate batch script to build the binaries if necessary.
+    pydevd_attach_to_process_root = os.path.join(pydevd_root, "pydevd_attach_to_process")
+    if os.name == "nt":
+        if not os.path.exists(os.path.join(pydevd_attach_to_process_root, "attach_amd64.dll")) or force:
+            os.system(os.path.join(pydevd_attach_to_process_root, "windows", "compile_windows.bat"))
+    elif os.name == "posix":
+        if not os.path.exists(os.path.join(pydevd_attach_to_process_root, "attach_linux_amd64.so")) or force:
+            os.system(os.path.join(pydevd_attach_to_process_root, "linux_and_mac", "compile_linux.sh"))
+    else:
+        if not os.path.exists(os.path.join(pydevd_attach_to_process_root, "attach_x86_64.dylib")) or force:
+            os.system(os.path.join(pydevd_attach_to_process_root, "linux_and_mac", "compile_mac.sh"))
+    
+
+if __name__ == "__main__":
+    arg_parser = argparse.ArgumentParser(description="Build the pydevd binaries.")
+    arg_parser.add_argument("--force", action='store_true', help="Force a rebuild")
+    args = arg_parser.parse_args()
+
+    build_pydevd_binaries(args.force)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,3 +20,7 @@ gevent
 numpy
 requests
 typing_extensions
+
+# Used to build pydevd attach to process binaries:
+pyMSVC
+Cython

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -22,5 +22,5 @@ requests
 typing_extensions
 
 # Used to build pydevd attach to process binaries:
-pyMSVC
+vswhere
 Cython

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps = -rtests/requirements.txt
 passenv = DEBUGPY_LOG_DIR,DEBUGPY_TESTS_FULL
 setenv =
     DEBUGPY_TEST=1
+commands_pre = python build_attach_binaries.py
 commands =
     py{38,39}-!cov: python -m pytest {posargs}
     py{38,39}-cov: python -m pytest --cov --cov-append --cov-config=.coveragerc {posargs}


### PR DESCRIPTION
Our contributing.MD doesn't mention how to make the attach binaries. This makes them just build as part of running tox.