### PR TITLE
Allow relative paths in the 'remotePath' for a launch.json

### DIFF
--- a/src/debugpy/_vendored/pydevd/pydevd_file_utils.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_file_utils.py
@@ -653,12 +653,6 @@ def _fix_path(path, sep, add_end_sep=False):
 
     if sep != "/":
         path = path.replace("/", sep)
-
-    if path.startswith("."):
-        # We need the full path if this relative because all comparisons below
-        # check if the path is substring of another
-        path = os.path.realpath(path)
-
     return path
 
 
@@ -753,16 +747,6 @@ def setup_client_server_paths(paths):
         initial_paths_with_end_sep.append((path0, path1))
         paths_from_eclipse_to_python_with_end_sep.append((_normcase_from_client(path0), normcase(path1)))
 
-    if DEBUG_CLIENT_SERVER_TRANSLATION:
-        pydev_log.critical(
-            "pydev debugger: paths_from_eclipse_to_python %s",
-            ", ".join(
-                [
-                    '"%s=>%s"' % (x[0], x[1])
-                    for x in paths_from_eclipse_to_python
-                ]
-            ),
-        )
     # Fix things so that we always match the versions with a slash in the end first.
     initial_paths = initial_paths_with_end_sep + initial_paths
     paths_from_eclipse_to_python = paths_from_eclipse_to_python_with_end_sep + paths_from_eclipse_to_python

--- a/src/debugpy/_vendored/pydevd/pydevd_file_utils.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_file_utils.py
@@ -653,6 +653,12 @@ def _fix_path(path, sep, add_end_sep=False):
 
     if sep != "/":
         path = path.replace("/", sep)
+
+    if path.startswith("."):
+        # We need the full path if this relative because all comparisons below
+        # check if the path is substring of another
+        path = os.path.realpath(path)
+
     return path
 
 
@@ -747,6 +753,16 @@ def setup_client_server_paths(paths):
         initial_paths_with_end_sep.append((path0, path1))
         paths_from_eclipse_to_python_with_end_sep.append((_normcase_from_client(path0), normcase(path1)))
 
+    if DEBUG_CLIENT_SERVER_TRANSLATION:
+        pydev_log.critical(
+            "pydev debugger: paths_from_eclipse_to_python %s",
+            ", ".join(
+                [
+                    '"%s=>%s"' % (x[0], x[1])
+                    for x in paths_from_eclipse_to_python
+                ]
+            ),
+        )
     # Fix things so that we always match the versions with a slash in the end first.
     initial_paths = initial_paths_with_end_sep + initial_paths
     paths_from_eclipse_to_python = paths_from_eclipse_to_python_with_end_sep + paths_from_eclipse_to_python

--- a/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
@@ -167,7 +167,7 @@ def test_source_reference(tmpdir):
 
         assert pydevd_file_utils.map_file_to_client(server_path) == ("C:\\foo\\my", True)
         assert pydevd_file_utils.get_client_filename_source_reference("C:\\foo\\my") == 0
-        assert pydevd_file_utils.map_file_to_server("c:\\foo\\my") == (server_path, True)
+        assert pydevd_file_utils.map_file_to_server("c:\\foo\\my") == server_path
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test.")

--- a/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
@@ -165,8 +165,9 @@ def test_source_reference(tmpdir):
         root = os.getcwd()
         server_path = os.path.join(root, "bar/my")
 
-        assert pydevd_file_utils.map_file_to_client(server_path) == ("c:\\foo\\my", True)
-        assert pydevd_file_utils.get_client_filename_source_reference("c:\\foo\\my") == 0
+        assert pydevd_file_utils.map_file_to_client(server_path) == ("C:\\foo\\my", True)
+        assert pydevd_file_utils.get_client_filename_source_reference("C:\\foo\\my") == 0
+        assert pydevd_file_utils.map_file_to_server("c:\\foo\\my") == (serverPath, True)
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test.")

--- a/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
@@ -167,7 +167,7 @@ def test_source_reference(tmpdir):
 
         assert pydevd_file_utils.map_file_to_client(server_path) == ("C:\\foo\\my", True)
         assert pydevd_file_utils.get_client_filename_source_reference("C:\\foo\\my") == 0
-        assert pydevd_file_utils.map_file_to_server("c:\\foo\\my") == (serverPath, True)
+        assert pydevd_file_utils.map_file_to_server("c:\\foo\\my") == (server_path, True)
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test.")

--- a/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
@@ -150,7 +150,7 @@ def test_source_reference(tmpdir):
         # Client on windows and server on unix
         pydevd_file_utils.set_ide_os("WINDOWS")
 
-        pydevd_file_utils.setup_client_server_paths([("C:\\foo", "/bar")])
+        pydevd_file_utils.setup_client_server_paths([("c:\\foo", "/bar")])
 
         assert pydevd_file_utils.map_file_to_client("/bar/my") == ("c:\\foo\\my", True)
         assert pydevd_file_utils.get_client_filename_source_reference("c:\\foo\\my") == 0
@@ -159,14 +159,6 @@ def test_source_reference(tmpdir):
         source_reference = pydevd_file_utils.get_client_filename_source_reference("\\another\\my")
         assert source_reference != 0
         assert pydevd_file_utils.get_server_filename_from_source_reference(source_reference) == "/another/my"
-
-        # Allow relative paths in the server path
-        pydevd_file_utils.setup_client_server_paths([("C:\\foo", "./bar")])
-        root = os.getcwd()
-        server_path = os.path.join(root, "bar/my")
-
-        assert pydevd_file_utils.map_file_to_client(server_path) == ("c:\\foo\\my", True)
-        assert pydevd_file_utils.get_client_filename_source_reference("c:\\foo\\my") == 0
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test.")

--- a/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
@@ -152,8 +152,8 @@ def test_source_reference(tmpdir):
 
         pydevd_file_utils.setup_client_server_paths([("C:\\foo", "/bar")])
 
-        assert pydevd_file_utils.map_file_to_client("/bar/my") == ("c:\\foo\\my", True)
-        assert pydevd_file_utils.get_client_filename_source_reference("c:\\foo\\my") == 0
+        assert pydevd_file_utils.map_file_to_client("/bar/my") == ("C:\\foo\\my", True)
+        assert pydevd_file_utils.get_client_filename_source_reference("C:\\foo\\my") == 0
 
         assert pydevd_file_utils.map_file_to_client("/another/my") == ("\\another\\my", False)
         source_reference = pydevd_file_utils.get_client_filename_source_reference("\\another\\my")

--- a/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_convert_utilities.py
@@ -150,7 +150,7 @@ def test_source_reference(tmpdir):
         # Client on windows and server on unix
         pydevd_file_utils.set_ide_os("WINDOWS")
 
-        pydevd_file_utils.setup_client_server_paths([("c:\\foo", "/bar")])
+        pydevd_file_utils.setup_client_server_paths([("C:\\foo", "/bar")])
 
         assert pydevd_file_utils.map_file_to_client("/bar/my") == ("c:\\foo\\my", True)
         assert pydevd_file_utils.get_client_filename_source_reference("c:\\foo\\my") == 0
@@ -159,6 +159,14 @@ def test_source_reference(tmpdir):
         source_reference = pydevd_file_utils.get_client_filename_source_reference("\\another\\my")
         assert source_reference != 0
         assert pydevd_file_utils.get_server_filename_from_source_reference(source_reference) == "/another/my"
+
+        # Allow relative paths in the server path
+        pydevd_file_utils.setup_client_server_paths([("C:\\foo", "./bar")])
+        root = os.getcwd()
+        server_path = os.path.join(root, "bar/my")
+
+        assert pydevd_file_utils.map_file_to_client(server_path) == ("c:\\foo\\my", True)
+        assert pydevd_file_utils.get_client_filename_source_reference("c:\\foo\\my") == 0
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test.")


### PR DESCRIPTION
Partial fix for https://github.com/microsoft/debugpy/issues/1301

Users in issue 1301 were attempting to do something like so:

```jsonc
"pathMappings": [
                {
                    "localRoot": "${workspaceFolder}",
                    "remoteRoot": "." // <-- '.' is not supported here.
                }
            ]
```

In pydevd this isn't supported. The remote and local roots have to be fully specified. This is a pain in a shared situation though as you can pass environment variables for the local path but not the remote.

This change allows the user to have a relative (to the current working directory) for the remote path.