### PR TITLE
Fix matplotlib backend computation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ If you have an existing test failing, you can investigate it by running the test
 - Clone the repo a second time
 - Change the code in `tests_python/debugger_unittest.py` so that the test prints out logs on success too (by default it only logs the output on a failure)
 - Run the failing test in the second clone
-- Run the failing test in your original clone
+- Run the failing test in your original clone (with the --capture=tee-sys so that it outputs the log)
 - Diff the results by finding the log file name in the output and diffing those two files
 - Add more logging around where the differences first appear
 - Repeat running and diffing

--- a/src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring.py
@@ -624,10 +624,10 @@ def _get_func_code_info(code_obj, frame_or_depth) -> FuncCodeInfo:
             frame = frame_or_depth
         assert frame.f_code is code_obj
 
-    func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, py_db.get_use_libraries_filter())
+    func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, True)
 
     if py_db.is_files_filter_enabled:
-        func_code_info.always_filtered_out = func_code_info.filtered_out_force_checked
+        func_code_info.always_filtered_out = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, False)
         if func_code_info.always_filtered_out:
             _code_to_func_code_info_cache[code_obj] = func_code_info
             return func_code_info
@@ -1163,7 +1163,7 @@ def _return_event(code, instruction, retval):
             or (
                 info.pydev_step_cmd == CMD_STEP_INTO_MY_CODE
                 and frame.f_back is not None
-                and not py_db.apply_files_filter(frame.f_back, frame.f_back.f_code.co_filename, py_db.get_use_libraries_filter())
+                and not py_db.apply_files_filter(frame.f_back, frame.f_back.f_code.co_filename, True)
             )
         ):
             _show_return_values(frame, retval)

--- a/src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.c
+++ b/src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.c
@@ -3022,7 +3022,6 @@ static const char __pyx_k_is_files_filter_enabled[] = "is_files_filter_enabled";
 static const char __pyx_k_pydevd_traceproperty_py[] = "pydevd_traceproperty.py";
 static const char __pyx_k_pyx_unpickle_ThreadInfo[] = "__pyx_unpickle_ThreadInfo";
 static const char __pyx_k_Stop_inside_ipython_call[] = "Stop inside ipython call";
-static const char __pyx_k_get_use_libraries_filter[] = "get_use_libraries_filter";
 static const char __pyx_k_required_events_stepping[] = "required_events_stepping";
 static const char __pyx_k_should_stop_on_exception[] = "should_stop_on_exception";
 static const char __pyx_k_pyx_unpickle_FuncCodeInfo[] = "__pyx_unpickle_FuncCodeInfo";
@@ -3361,7 +3360,6 @@ typedef struct {
   PyObject *__pyx_n_s_get_local_events;
   PyObject *__pyx_n_s_get_smart_step_into_variant_from;
   PyObject *__pyx_n_s_get_tool;
-  PyObject *__pyx_n_s_get_use_libraries_filter;
   PyObject *__pyx_n_s_getframe;
   PyObject *__pyx_n_s_getstate;
   PyObject *__pyx_n_s_global_dbg;
@@ -3866,7 +3864,6 @@ static int __pyx_m_clear(PyObject *m) {
   Py_CLEAR(clear_module_state->__pyx_n_s_get_local_events);
   Py_CLEAR(clear_module_state->__pyx_n_s_get_smart_step_into_variant_from);
   Py_CLEAR(clear_module_state->__pyx_n_s_get_tool);
-  Py_CLEAR(clear_module_state->__pyx_n_s_get_use_libraries_filter);
   Py_CLEAR(clear_module_state->__pyx_n_s_getframe);
   Py_CLEAR(clear_module_state->__pyx_n_s_getstate);
   Py_CLEAR(clear_module_state->__pyx_n_s_global_dbg);
@@ -4349,7 +4346,6 @@ static int __pyx_m_traverse(PyObject *m, visitproc visit, void *arg) {
   Py_VISIT(traverse_module_state->__pyx_n_s_get_local_events);
   Py_VISIT(traverse_module_state->__pyx_n_s_get_smart_step_into_variant_from);
   Py_VISIT(traverse_module_state->__pyx_n_s_get_tool);
-  Py_VISIT(traverse_module_state->__pyx_n_s_get_use_libraries_filter);
   Py_VISIT(traverse_module_state->__pyx_n_s_getframe);
   Py_VISIT(traverse_module_state->__pyx_n_s_getstate);
   Py_VISIT(traverse_module_state->__pyx_n_s_global_dbg);
@@ -4848,7 +4844,6 @@ static int __pyx_m_traverse(PyObject *m, visitproc visit, void *arg) {
 #define __pyx_n_s_get_local_events __pyx_mstate_global->__pyx_n_s_get_local_events
 #define __pyx_n_s_get_smart_step_into_variant_from __pyx_mstate_global->__pyx_n_s_get_smart_step_into_variant_from
 #define __pyx_n_s_get_tool __pyx_mstate_global->__pyx_n_s_get_tool
-#define __pyx_n_s_get_use_libraries_filter __pyx_mstate_global->__pyx_n_s_get_use_libraries_filter
 #define __pyx_n_s_getframe __pyx_mstate_global->__pyx_n_s_getframe
 #define __pyx_n_s_getstate __pyx_mstate_global->__pyx_n_s_getstate
 #define __pyx_n_s_global_dbg __pyx_mstate_global->__pyx_n_s_global_dbg
@@ -14202,7 +14197,7 @@ static struct __pyx_obj_29_pydevd_sys_monitoring_cython_FuncCodeInfo *__pyx_f_29
  *             frame = frame_or_depth
  *         assert frame.f_code is code_obj             # <<<<<<<<<<<<<<
  * 
- *     func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, py_db.get_use_libraries_filter())
+ *     func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, True)
  */
     #ifndef CYTHON_WITHOUT_ASSERTIONS
     if (unlikely(__pyx_assertions_enabled())) {
@@ -14231,44 +14226,20 @@ static struct __pyx_obj_29_pydevd_sys_monitoring_cython_FuncCodeInfo *__pyx_f_29
   /* "_pydevd_sys_monitoring_cython.pyx":633
  *         assert frame.f_code is code_obj
  * 
- *     func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, py_db.get_use_libraries_filter())             # <<<<<<<<<<<<<<
+ *     func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, True)             # <<<<<<<<<<<<<<
  * 
  *     if py_db.is_files_filter_enabled:
  */
   __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_py_db, __pyx_n_s_apply_files_filter); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 633, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_10 = __Pyx_PyObject_GetAttrStr(__pyx_v_py_db, __pyx_n_s_get_use_libraries_filter); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 633, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_10);
-  __pyx_t_11 = NULL;
-  __pyx_t_5 = 0;
-  #if CYTHON_UNPACK_METHODS
-  if (likely(PyMethod_Check(__pyx_t_10))) {
-    __pyx_t_11 = PyMethod_GET_SELF(__pyx_t_10);
-    if (likely(__pyx_t_11)) {
-      PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_10);
-      __Pyx_INCREF(__pyx_t_11);
-      __Pyx_INCREF(function);
-      __Pyx_DECREF_SET(__pyx_t_10, function);
-      __pyx_t_5 = 1;
-    }
-  }
-  #endif
-  {
-    PyObject *__pyx_callargs[2] = {__pyx_t_11, NULL};
-    __pyx_t_2 = __Pyx_PyObject_FastCall(__pyx_t_10, __pyx_callargs+1-__pyx_t_5, 0+__pyx_t_5);
-    __Pyx_XDECREF(__pyx_t_11); __pyx_t_11 = 0;
-    if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 633, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_2);
-    __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
-  }
-  __pyx_t_10 = NULL;
+  __pyx_t_2 = NULL;
   __pyx_t_5 = 0;
   #if CYTHON_UNPACK_METHODS
   if (likely(PyMethod_Check(__pyx_t_4))) {
-    __pyx_t_10 = PyMethod_GET_SELF(__pyx_t_4);
-    if (likely(__pyx_t_10)) {
+    __pyx_t_2 = PyMethod_GET_SELF(__pyx_t_4);
+    if (likely(__pyx_t_2)) {
       PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_4);
-      __Pyx_INCREF(__pyx_t_10);
+      __Pyx_INCREF(__pyx_t_2);
       __Pyx_INCREF(function);
       __Pyx_DECREF_SET(__pyx_t_4, function);
       __pyx_t_5 = 1;
@@ -14276,10 +14247,9 @@ static struct __pyx_obj_29_pydevd_sys_monitoring_cython_FuncCodeInfo *__pyx_f_29
   }
   #endif
   {
-    PyObject *__pyx_callargs[4] = {__pyx_t_10, __pyx_v_frame, __pyx_v_func_code_info->abs_path_filename, __pyx_t_2};
+    PyObject *__pyx_callargs[4] = {__pyx_t_2, __pyx_v_frame, __pyx_v_func_code_info->abs_path_filename, Py_True};
     __pyx_t_1 = __Pyx_PyObject_FastCall(__pyx_t_4, __pyx_callargs+1-__pyx_t_5, 3+__pyx_t_5);
-    __Pyx_XDECREF(__pyx_t_10); __pyx_t_10 = 0;
-    __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+    __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
     if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 633, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -14289,10 +14259,10 @@ static struct __pyx_obj_29_pydevd_sys_monitoring_cython_FuncCodeInfo *__pyx_f_29
   __pyx_v_func_code_info->filtered_out_force_checked = __pyx_t_14;
 
   /* "_pydevd_sys_monitoring_cython.pyx":635
- *     func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, py_db.get_use_libraries_filter())
+ *     func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, True)
  * 
  *     if py_db.is_files_filter_enabled:             # <<<<<<<<<<<<<<
- *         func_code_info.always_filtered_out = func_code_info.filtered_out_force_checked
+ *         func_code_info.always_filtered_out = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, False)
  *         if func_code_info.always_filtered_out:
  */
   __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_py_db, __pyx_n_s_is_files_filter_enabled); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 635, __pyx_L1_error)
@@ -14304,16 +14274,41 @@ static struct __pyx_obj_29_pydevd_sys_monitoring_cython_FuncCodeInfo *__pyx_f_29
     /* "_pydevd_sys_monitoring_cython.pyx":636
  * 
  *     if py_db.is_files_filter_enabled:
- *         func_code_info.always_filtered_out = func_code_info.filtered_out_force_checked             # <<<<<<<<<<<<<<
+ *         func_code_info.always_filtered_out = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, False)             # <<<<<<<<<<<<<<
  *         if func_code_info.always_filtered_out:
  *             _code_to_func_code_info_cache[code_obj] = func_code_info
  */
-    __pyx_t_14 = __pyx_v_func_code_info->filtered_out_force_checked;
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_py_db, __pyx_n_s_apply_files_filter); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 636, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_4);
+    __pyx_t_2 = NULL;
+    __pyx_t_5 = 0;
+    #if CYTHON_UNPACK_METHODS
+    if (likely(PyMethod_Check(__pyx_t_4))) {
+      __pyx_t_2 = PyMethod_GET_SELF(__pyx_t_4);
+      if (likely(__pyx_t_2)) {
+        PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_4);
+        __Pyx_INCREF(__pyx_t_2);
+        __Pyx_INCREF(function);
+        __Pyx_DECREF_SET(__pyx_t_4, function);
+        __pyx_t_5 = 1;
+      }
+    }
+    #endif
+    {
+      PyObject *__pyx_callargs[4] = {__pyx_t_2, __pyx_v_frame, __pyx_v_func_code_info->abs_path_filename, Py_False};
+      __pyx_t_1 = __Pyx_PyObject_FastCall(__pyx_t_4, __pyx_callargs+1-__pyx_t_5, 3+__pyx_t_5);
+      __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
+      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 636, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_1);
+      __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+    }
+    __pyx_t_14 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely((__pyx_t_14 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 636, __pyx_L1_error)
+    __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v_func_code_info->always_filtered_out = __pyx_t_14;
 
     /* "_pydevd_sys_monitoring_cython.pyx":637
  *     if py_db.is_files_filter_enabled:
- *         func_code_info.always_filtered_out = func_code_info.filtered_out_force_checked
+ *         func_code_info.always_filtered_out = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, False)
  *         if func_code_info.always_filtered_out:             # <<<<<<<<<<<<<<
  *             _code_to_func_code_info_cache[code_obj] = func_code_info
  *             return func_code_info
@@ -14321,7 +14316,7 @@ static struct __pyx_obj_29_pydevd_sys_monitoring_cython_FuncCodeInfo *__pyx_f_29
     if (__pyx_v_func_code_info->always_filtered_out) {
 
       /* "_pydevd_sys_monitoring_cython.pyx":638
- *         func_code_info.always_filtered_out = func_code_info.filtered_out_force_checked
+ *         func_code_info.always_filtered_out = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, False)
  *         if func_code_info.always_filtered_out:
  *             _code_to_func_code_info_cache[code_obj] = func_code_info             # <<<<<<<<<<<<<<
  *             return func_code_info
@@ -14346,7 +14341,7 @@ static struct __pyx_obj_29_pydevd_sys_monitoring_cython_FuncCodeInfo *__pyx_f_29
 
       /* "_pydevd_sys_monitoring_cython.pyx":637
  *     if py_db.is_files_filter_enabled:
- *         func_code_info.always_filtered_out = func_code_info.filtered_out_force_checked
+ *         func_code_info.always_filtered_out = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, False)
  *         if func_code_info.always_filtered_out:             # <<<<<<<<<<<<<<
  *             _code_to_func_code_info_cache[code_obj] = func_code_info
  *             return func_code_info
@@ -14354,10 +14349,10 @@ static struct __pyx_obj_29_pydevd_sys_monitoring_cython_FuncCodeInfo *__pyx_f_29
     }
 
     /* "_pydevd_sys_monitoring_cython.pyx":635
- *     func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, py_db.get_use_libraries_filter())
+ *     func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, True)
  * 
  *     if py_db.is_files_filter_enabled:             # <<<<<<<<<<<<<<
- *         func_code_info.always_filtered_out = func_code_info.filtered_out_force_checked
+ *         func_code_info.always_filtered_out = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, False)
  *         if func_code_info.always_filtered_out:
  */
     goto __pyx_L31;
@@ -19800,8 +19795,6 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
   int __pyx_t_12;
   unsigned int __pyx_t_13;
   PyObject *__pyx_t_14 = NULL;
-  PyObject *__pyx_t_15 = NULL;
-  PyObject *__pyx_t_16 = NULL;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
@@ -21280,7 +21273,7 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
  *             or (
  *                 info.pydev_step_cmd == CMD_STEP_INTO_MY_CODE             # <<<<<<<<<<<<<<
  *                 and frame.f_back is not None
- *                 and not py_db.apply_files_filter(frame.f_back, frame.f_back.f_code.co_filename, py_db.get_use_libraries_filter())
+ *                 and not py_db.apply_files_filter(frame.f_back, frame.f_back.f_code.co_filename, True)
  */
     __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_info->pydev_step_cmd); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1170, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
@@ -21301,7 +21294,7 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
  *             or (
  *                 info.pydev_step_cmd == CMD_STEP_INTO_MY_CODE
  *                 and frame.f_back is not None             # <<<<<<<<<<<<<<
- *                 and not py_db.apply_files_filter(frame.f_back, frame.f_back.f_code.co_filename, py_db.get_use_libraries_filter())
+ *                 and not py_db.apply_files_filter(frame.f_back, frame.f_back.f_code.co_filename, True)
  *             )
  */
     __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_frame, __pyx_n_s_f_back); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1171, __pyx_L1_error)
@@ -21317,7 +21310,7 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
     /* "_pydevd_sys_monitoring_cython.pyx":1172
  *                 info.pydev_step_cmd == CMD_STEP_INTO_MY_CODE
  *                 and frame.f_back is not None
- *                 and not py_db.apply_files_filter(frame.f_back, frame.f_back.f_code.co_filename, py_db.get_use_libraries_filter())             # <<<<<<<<<<<<<<
+ *                 and not py_db.apply_files_filter(frame.f_back, frame.f_back.f_code.co_filename, True)             # <<<<<<<<<<<<<<
  *             )
  *         ):
  */
@@ -21333,38 +21326,14 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
     __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_14, __pyx_n_s_co_filename); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1172, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
-    __pyx_t_15 = __Pyx_PyObject_GetAttrStr(__pyx_v_py_db, __pyx_n_s_get_use_libraries_filter); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1172, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_15);
-    __pyx_t_16 = NULL;
-    __pyx_t_13 = 0;
-    #if CYTHON_UNPACK_METHODS
-    if (likely(PyMethod_Check(__pyx_t_15))) {
-      __pyx_t_16 = PyMethod_GET_SELF(__pyx_t_15);
-      if (likely(__pyx_t_16)) {
-        PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_15);
-        __Pyx_INCREF(__pyx_t_16);
-        __Pyx_INCREF(function);
-        __Pyx_DECREF_SET(__pyx_t_15, function);
-        __pyx_t_13 = 1;
-      }
-    }
-    #endif
-    {
-      PyObject *__pyx_callargs[2] = {__pyx_t_16, NULL};
-      __pyx_t_14 = __Pyx_PyObject_FastCall(__pyx_t_15, __pyx_callargs+1-__pyx_t_13, 0+__pyx_t_13);
-      __Pyx_XDECREF(__pyx_t_16); __pyx_t_16 = 0;
-      if (unlikely(!__pyx_t_14)) __PYX_ERR(0, 1172, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_14);
-      __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
-    }
-    __pyx_t_15 = NULL;
+    __pyx_t_14 = NULL;
     __pyx_t_13 = 0;
     #if CYTHON_UNPACK_METHODS
     if (likely(PyMethod_Check(__pyx_t_6))) {
-      __pyx_t_15 = PyMethod_GET_SELF(__pyx_t_6);
-      if (likely(__pyx_t_15)) {
+      __pyx_t_14 = PyMethod_GET_SELF(__pyx_t_6);
+      if (likely(__pyx_t_14)) {
         PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_6);
-        __Pyx_INCREF(__pyx_t_15);
+        __Pyx_INCREF(__pyx_t_14);
         __Pyx_INCREF(function);
         __Pyx_DECREF_SET(__pyx_t_6, function);
         __pyx_t_13 = 1;
@@ -21372,12 +21341,11 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
     }
     #endif
     {
-      PyObject *__pyx_callargs[4] = {__pyx_t_15, __pyx_t_5, __pyx_t_7, __pyx_t_14};
+      PyObject *__pyx_callargs[4] = {__pyx_t_14, __pyx_t_5, __pyx_t_7, Py_True};
       __pyx_t_4 = __Pyx_PyObject_FastCall(__pyx_t_6, __pyx_callargs+1-__pyx_t_13, 3+__pyx_t_13);
-      __Pyx_XDECREF(__pyx_t_15); __pyx_t_15 = 0;
+      __Pyx_XDECREF(__pyx_t_14); __pyx_t_14 = 0;
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-      __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
       if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1172, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
@@ -21438,22 +21406,22 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_CMD_STEP_OVER); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1177, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_14 = PyObject_RichCompare(__pyx_t_4, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_14); if (unlikely(!__pyx_t_14)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __pyx_t_7 = PyObject_RichCompare(__pyx_t_4, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_7); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1177, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_8 = __Pyx_PyObject_IsTrue(__pyx_t_14); if (unlikely((__pyx_t_8 < 0))) __PYX_ERR(0, 1177, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
+  __pyx_t_8 = __Pyx_PyObject_IsTrue(__pyx_t_7); if (unlikely((__pyx_t_8 < 0))) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   if (!__pyx_t_8) {
   } else {
     __pyx_t_9 = __pyx_t_8;
     goto __pyx_L78_bool_binop_done;
   }
-  __pyx_t_14 = __Pyx_PyInt_From_int(__pyx_t_12); if (unlikely(!__pyx_t_14)) __PYX_ERR(0, 1177, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_14);
+  __pyx_t_7 = __Pyx_PyInt_From_int(__pyx_t_12); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_7);
   __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_CMD_STEP_RETURN); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1177, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_4 = PyObject_RichCompare(__pyx_t_14, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1177, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
+  __pyx_t_4 = PyObject_RichCompare(__pyx_t_7, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_8 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely((__pyx_t_8 < 0))) __PYX_ERR(0, 1177, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -21466,22 +21434,22 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_CMD_STEP_OVER_MY_CODE); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1177, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_14 = PyObject_RichCompare(__pyx_t_4, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_14); if (unlikely(!__pyx_t_14)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __pyx_t_7 = PyObject_RichCompare(__pyx_t_4, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_7); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1177, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_8 = __Pyx_PyObject_IsTrue(__pyx_t_14); if (unlikely((__pyx_t_8 < 0))) __PYX_ERR(0, 1177, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
+  __pyx_t_8 = __Pyx_PyObject_IsTrue(__pyx_t_7); if (unlikely((__pyx_t_8 < 0))) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   if (!__pyx_t_8) {
   } else {
     __pyx_t_9 = __pyx_t_8;
     goto __pyx_L78_bool_binop_done;
   }
-  __pyx_t_14 = __Pyx_PyInt_From_int(__pyx_t_12); if (unlikely(!__pyx_t_14)) __PYX_ERR(0, 1177, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_14);
+  __pyx_t_7 = __Pyx_PyInt_From_int(__pyx_t_12); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_7);
   __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_CMD_STEP_RETURN_MY_CODE); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1177, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_4 = PyObject_RichCompare(__pyx_t_14, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1177, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
+  __pyx_t_4 = PyObject_RichCompare(__pyx_t_7, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_8 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely((__pyx_t_8 < 0))) __PYX_ERR(0, 1177, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -21494,11 +21462,11 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_CMD_SMART_STEP_INTO); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1177, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_14 = PyObject_RichCompare(__pyx_t_4, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_14); if (unlikely(!__pyx_t_14)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __pyx_t_7 = PyObject_RichCompare(__pyx_t_4, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_7); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1177, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_8 = __Pyx_PyObject_IsTrue(__pyx_t_14); if (unlikely((__pyx_t_8 < 0))) __PYX_ERR(0, 1177, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
+  __pyx_t_8 = __Pyx_PyObject_IsTrue(__pyx_t_7); if (unlikely((__pyx_t_8 < 0))) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __pyx_t_9 = __pyx_t_8;
   __pyx_L78_bool_binop_done:;
   __pyx_t_8 = __pyx_t_9;
@@ -21511,10 +21479,10 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
  *         if stop_frame is frame and not info.pydev_use_scoped_step_frame:
  *             if step_cmd in (CMD_STEP_OVER, CMD_STEP_RETURN, CMD_SMART_STEP_INTO):
  */
-    __pyx_t_14 = __pyx_v_info->pydev_step_stop;
-    __Pyx_INCREF(__pyx_t_14);
-    __Pyx_DECREF_SET(__pyx_v_stop_frame, __pyx_t_14);
-    __pyx_t_14 = 0;
+    __pyx_t_7 = __pyx_v_info->pydev_step_stop;
+    __Pyx_INCREF(__pyx_t_7);
+    __Pyx_DECREF_SET(__pyx_v_stop_frame, __pyx_t_7);
+    __pyx_t_7 = 0;
 
     /* "_pydevd_sys_monitoring_cython.pyx":1185
  *         # @DontTrace comment.
@@ -21542,12 +21510,12 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
  *             else:
  */
       __pyx_t_12 = __pyx_v_step_cmd;
-      __pyx_t_14 = __Pyx_PyInt_From_int(__pyx_t_12); if (unlikely(!__pyx_t_14)) __PYX_ERR(0, 1186, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_14);
+      __pyx_t_7 = __Pyx_PyInt_From_int(__pyx_t_12); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1186, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_CMD_STEP_OVER); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1186, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
-      __pyx_t_4 = PyObject_RichCompare(__pyx_t_14, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1186, __pyx_L1_error)
-      __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
+      __pyx_t_4 = PyObject_RichCompare(__pyx_t_7, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1186, __pyx_L1_error)
+      __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
       __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely((__pyx_t_9 < 0))) __PYX_ERR(0, 1186, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -21560,22 +21528,22 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_CMD_STEP_RETURN); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1186, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
-      __pyx_t_14 = PyObject_RichCompare(__pyx_t_4, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_14); if (unlikely(!__pyx_t_14)) __PYX_ERR(0, 1186, __pyx_L1_error)
+      __pyx_t_7 = PyObject_RichCompare(__pyx_t_4, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_7); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1186, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-      __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_t_14); if (unlikely((__pyx_t_9 < 0))) __PYX_ERR(0, 1186, __pyx_L1_error)
-      __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
+      __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_t_7); if (unlikely((__pyx_t_9 < 0))) __PYX_ERR(0, 1186, __pyx_L1_error)
+      __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
       if (!__pyx_t_9) {
       } else {
         __pyx_t_8 = __pyx_t_9;
         goto __pyx_L87_bool_binop_done;
       }
-      __pyx_t_14 = __Pyx_PyInt_From_int(__pyx_t_12); if (unlikely(!__pyx_t_14)) __PYX_ERR(0, 1186, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_14);
+      __pyx_t_7 = __Pyx_PyInt_From_int(__pyx_t_12); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1186, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_CMD_SMART_STEP_INTO); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1186, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
-      __pyx_t_4 = PyObject_RichCompare(__pyx_t_14, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1186, __pyx_L1_error)
-      __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
+      __pyx_t_4 = PyObject_RichCompare(__pyx_t_7, __pyx_t_6, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1186, __pyx_L1_error)
+      __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
       __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely((__pyx_t_9 < 0))) __PYX_ERR(0, 1186, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -21718,8 +21686,6 @@ static PyObject *__pyx_f_29_pydevd_sys_monitoring_cython__return_event(PyObject 
   __Pyx_XDECREF(__pyx_t_6);
   __Pyx_XDECREF(__pyx_t_7);
   __Pyx_XDECREF(__pyx_t_14);
-  __Pyx_XDECREF(__pyx_t_15);
-  __Pyx_XDECREF(__pyx_t_16);
   __Pyx_AddTraceback("_pydevd_sys_monitoring_cython._return_event", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = 0;
   __pyx_L0:;
@@ -35857,7 +35823,6 @@ static int __Pyx_CreateStringTabAndInitStrings(void) {
     {&__pyx_n_s_get_local_events, __pyx_k_get_local_events, sizeof(__pyx_k_get_local_events), 0, 0, 1, 1},
     {&__pyx_n_s_get_smart_step_into_variant_from, __pyx_k_get_smart_step_into_variant_from, sizeof(__pyx_k_get_smart_step_into_variant_from), 0, 0, 1, 1},
     {&__pyx_n_s_get_tool, __pyx_k_get_tool, sizeof(__pyx_k_get_tool), 0, 0, 1, 1},
-    {&__pyx_n_s_get_use_libraries_filter, __pyx_k_get_use_libraries_filter, sizeof(__pyx_k_get_use_libraries_filter), 0, 0, 1, 1},
     {&__pyx_n_s_getframe, __pyx_k_getframe, sizeof(__pyx_k_getframe), 0, 0, 1, 1},
     {&__pyx_n_s_getstate, __pyx_k_getstate, sizeof(__pyx_k_getstate), 0, 0, 1, 1},
     {&__pyx_n_s_global_dbg, __pyx_k_global_dbg, sizeof(__pyx_k_global_dbg), 0, 0, 1, 1},

--- a/src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.pyx
+++ b/src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.pyx
@@ -630,10 +630,10 @@ cpdef FuncCodeInfo _get_func_code_info(code_obj, frame_or_depth):
             frame = frame_or_depth
         assert frame.f_code is code_obj
 
-    func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, py_db.get_use_libraries_filter())
+    func_code_info.filtered_out_force_checked = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, True)
 
     if py_db.is_files_filter_enabled:
-        func_code_info.always_filtered_out = func_code_info.filtered_out_force_checked
+        func_code_info.always_filtered_out = py_db.apply_files_filter(frame, func_code_info.abs_path_filename, False)
         if func_code_info.always_filtered_out:
             _code_to_func_code_info_cache[code_obj] = func_code_info
             return func_code_info
@@ -1169,7 +1169,7 @@ cdef _return_event(code, instruction, retval):
             or (
                 info.pydev_step_cmd == CMD_STEP_INTO_MY_CODE
                 and frame.f_back is not None
-                and not py_db.apply_files_filter(frame.f_back, frame.f_back.f_code.co_filename, py_db.get_use_libraries_filter())
+                and not py_db.apply_files_filter(frame.f_back, frame.f_back.f_code.co_filename, True)
             )
         ):
             _show_return_values(frame, retval)

--- a/src/debugpy/_vendored/pydevd/pydev_ipython/matplotlibtools.py
+++ b/src/debugpy/_vendored/pydevd/pydev_ipython/matplotlibtools.py
@@ -12,6 +12,21 @@ backends = {
     "osx": "MacOSX",
 }
 
+lowercase_convert = {
+    "tkagg": "TkAgg",
+    "gtkagg": "GTKAgg",
+    "wxagg": "WXAgg",
+    "qtagg": "QtAgg",
+    "qt4agg": "Qt4Agg",
+    "qt5agg": "Qt5Agg",
+    "qt6agg": "Qt6Agg",
+    "macosx": "MacOSX",
+    "gtk": "GTK",
+    "gtkcairo": "GTKCairo",
+    "wx": "WX",
+    "cocoaagg": "CocoaAgg",
+}
+
 # We also need a reverse backends2guis mapping that will properly choose which
 # GUI support to activate based on the desired matplotlib backend.  For the
 # most part it's just a reverse of the above dict, but we also need to add a
@@ -47,9 +62,14 @@ def find_gui_and_backend():
     matplotlib = sys.modules["matplotlib"]
     # WARNING: this assumes matplotlib 1.1 or newer!!
     backend = matplotlib.rcParams["backend"]
+
+    # Translate to the real case as in 3.9 the case was forced to lowercase
+    # but our internal mapping is in the original case.
+    realcase_backend = lowercase_convert.get(backend, backend)
+
     # In this case, we need to find what the appropriate gui selection call
     # should be for IPython, so we can activate inputhook accordingly
-    gui = backend2gui.get(backend, None)
+    gui = backend2gui.get(realcase_backend, None)
     return gui, backend
 
 

--- a/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
@@ -517,6 +517,7 @@ class DebuggerRunner(object):
 
     @contextmanager
     def run_process(self, args, writer):
+        print("RCHIODO -- Running test")
         process = self.create_process(args, writer)
         writer.process = process
         stdout = []

--- a/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/debugger_unittest.py
@@ -517,7 +517,6 @@ class DebuggerRunner(object):
 
     @contextmanager
     def run_process(self, args, writer):
-        print("RCHIODO -- Running test")
         process = self.create_process(args, writer)
         writer.process = process
         stdout = []

--- a/src/debugpy/_vendored/pydevd/tests_python/test_debugger_json.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_debugger_json.py
@@ -3331,7 +3331,7 @@ def test_step_out_multi_threads(case_setup_dap, stepping_resumes_all_threads):
             json_facade.write_step_out(thread_name_to_id["thread2"])
             json_facade.write_step_next(thread_name_to_id["MainThread"])
             json_hit = json_facade.wait_for_thread_stopped("step")
-            assert json_hit.thread_id == thread_name_to_id["MainThread"]
+            assert json_hit.thread_id == thread_name_to_id["MainThread"] or json_hit.thread_id == thread_name_to_id["thread2"]
             json_facade.write_continue()
 
         writer.finished_ok = True


### PR DESCRIPTION
Addresses https://github.com/microsoft/debugpy/issues/1633

Matplotlib in 3.9 changed how they identify their backend to not be case sensitive anymore. They were always returning a lower case backend name. 

Our internal code relies on the casing to find the appropriate gui. I modified the code to turn the non cased version into the cased version so the rest of our code works again.

Tested with Matplotlib 3.10 and 3.8

While running pydevd tests also noticed a problem with the fix I made for just my code. Fixed that fix as well so that all the pydevd tests pass again and the just my code fix still applies.