### PR TITLE
Fix binskim warnings for mac, linux, and pyd files

### DIFF
--- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac/compile_linux.sh
+++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac/compile_linux.sh
@@ -8,4 +8,4 @@ case $ARCH in
 esac
 
 SRC="$(dirname "$0")/.."
-g++ -std=c++11 -shared -fPIC -nostartfiles $SRC/linux_and_mac/attach.cpp -o $SRC/attach_linux_$SUFFIX.so
+g++ -std=c++11 -shared -fPIC -D_FORTIFY_SOURCE=2 -nostartfiles $SRC/linux_and_mac/attach.cpp -o $SRC/attach_linux_$SUFFIX.so

--- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac/compile_mac.sh
+++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac/compile_mac.sh
@@ -1,4 +1,4 @@
 set -e
 SRC="$(dirname "$0")/.."
-g++ -fPIC -D_REENTRANT -std=c++11 -arch x86_64 -c $SRC/linux_and_mac/attach.cpp -o $SRC/attach_x86_64.o
+g++ -fPIC -D_REENTRANT -std=c++11 -D_FORTIFY_SOURCE=2 -arch x86_64 -c $SRC/linux_and_mac/attach.cpp -o $SRC/attach_x86_64.o
 g++ -dynamiclib -nostartfiles -arch x86_64 -lc $SRC/attach_x86_64.o -o $SRC/attach_x86_64.dylib

--- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac/compile_manylinux.cmd
+++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac/compile_manylinux.cmd
@@ -5,6 +5,6 @@
 ::   [wsl2]
 ::   kernelCommandLine = vsyscall=emulate
 
-docker run --rm -v %~dp0/..:/src quay.io/pypa/manylinux1_x86_64 g++ -std=c++11 -shared -o /src/attach_linux_amd64.so -fPIC -nostartfiles /src/linux_and_mac/attach.cpp
+docker run --rm -v %~dp0/..:/src quay.io/pypa/manylinux1_x86_64 g++ -std=c++11 -D_FORTIFY_SOURCE=2 -shared -o /src/attach_linux_amd64.so -fPIC -nostartfiles /src/linux_and_mac/attach.cpp
 
-docker run --rm -v %~dp0/..:/src quay.io/pypa/manylinux1_i686 g++ -std=c++11 -shared -o /src/attach_linux_x86.so -fPIC -nostartfiles /src/linux_and_mac/attach.cpp
+docker run --rm -v %~dp0/..:/src quay.io/pypa/manylinux1_i686 g++ -std=c++11 -D_FORTIFY_SOURCE=2 -shared -o /src/attach_linux_x86.so -fPIC -nostartfiles /src/linux_and_mac/attach.cpp

--- a/src/debugpy/_vendored/pydevd/setup.py
+++ b/src/debugpy/_vendored/pydevd/setup.py
@@ -170,6 +170,8 @@ try:
         # uncomment to generate pdbs for visual studio.
         # extra_compile_args=["-Zi", "/Od"]
         # extra_link_args=["-debug"]
+        extra_compile_args = ["/guard:cf"]
+        extra_link_args = ["/guard:cf", "/DYNAMICBASE"]
 
     kwargs = {}
     if extra_link_args:

--- a/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
+++ b/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
@@ -207,6 +207,8 @@ def build_extension(dir_name, extension_name, target_pydevd_name, force_cython, 
             # uncomment to generate pdbs for visual studio.
             # extra_compile_args=["-Zi", "/Od"]
             # extra_link_args=["-debug"]
+            extra_compile_args = ["/guard:cf"]
+            extra_link_args = ["/guard:cf", "/DYNAMICBASE"]
             if IS_PY311_ONWARDS:
                 # On py311 we need to add the CPython include folder to the include path.
                 extra_compile_args.append("-I%s\\include\\CPython" % sys.exec_prefix)


### PR DESCRIPTION
See this query here:

https://devdiv.visualstudio.com/DevDiv/_queries/query/?_a=query&tempQueryId=157610c7-3a9b-4c62-858c-a0435f90e015

I believe these changes will make those warnings go away. 