### PR TITLE
Ensure Debugpy closes connection after a disconnect response

### DIFF
--- a/src/debugpy/adapter/clients.py
+++ b/src/debugpy/adapter/clients.py
@@ -700,6 +700,12 @@ class Client(components.Component):
                 except Exception:
                     log.swallow_exception()
 
+        # Close the client channel since we disconnected from the client.
+        try:
+            self.channel.close()
+        except Exception:
+            log.swallow_exception(level="warning")
+
     def disconnect(self):
         super().disconnect()
 

--- a/src/debugpy/common/messaging.py
+++ b/src/debugpy/common/messaging.py
@@ -1223,14 +1223,6 @@ class JsonMessageChannel(object):
             yield seq
             self.stream.write_json(message)
 
-        # Close connection after Debugpy acknowledges a disconnect request.
-        if (
-            message.get("type") == "response"
-            and message.get("command") == "disconnect"
-            and message.get("success", False)
-        ):
-            self.stream.close()
-
     def send_request(self, command, arguments=None, on_before_send=None):
         """Sends a new request, and returns the OutgoingRequest object for it.
 

--- a/src/debugpy/common/messaging.py
+++ b/src/debugpy/common/messaging.py
@@ -1223,6 +1223,14 @@ class JsonMessageChannel(object):
             yield seq
             self.stream.write_json(message)
 
+        # Close connection after Debugpy acknowledges a disconnect request.
+        if (
+            message.get("type") == "response"
+            and message.get("command") == "disconnect"
+            and message.get("success", False)
+        ):
+            self.stream.close()
+
     def send_request(self, command, arguments=None, on_before_send=None):
         """Sends a new request, and returns the OutgoingRequest object for it.
 


### PR DESCRIPTION
Until now, the process of closing the connection between Debugpy and a client (e.g. VSCode) would be the following:

1. a client sends a disconnect request,
2. Debugpy sends back a disconnect response acknowledging the disconnect,
3. the client sends an empty line,
4. Debugpy waits for an empty line and only then closes connection ([link to code](https://github.com/microsoft/debugpy/blob/v1.8.13/src/debugpy/common/messaging.py#L171)).

The problem is that, unlike VSCode, not all clients send this empty line. Because of that, when a user shuts down the debugger, the Debugpy's process won't die. It keeps waiting for that empty line to close the connection and at the same time occupying the communication port with the client. I believe this is the reason for the bug reported in #1783.

AFAIK, sending an empty line is not a part of the DAP protocol. Therefore, Debugpy shouldn't rely on it and should instead proactively close connection once it sends a disconnect response to the client.

This PR aims to fix this.