### PR TITLE
Account for the scope when changing variables

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -934,7 +934,7 @@ def internal_change_variable_json(py_db, request):
         )
         return
 
-    child_var = variable.change_variable(arguments.name, arguments.value, py_db, fmt=fmt)
+    child_var = variable.change_variable(arguments.name, arguments.value, py_db, fmt=fmt, scope=scope)
 
     if child_var is None:
         _write_variable_response(py_db, request, value="", success=False, message="Unable to change: %s." % (arguments.name,))

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_plugin_utils.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_plugin_utils.py
@@ -199,7 +199,7 @@ class PluginManager(object):
 
         return None
 
-    def change_variable(self, frame, attr, expression):
+    def change_variable(self, frame, attr, expression, scope=None):
         for plugin in self.active_plugins:
             ret = plugin.change_variable(frame, attr, expression, self.EMPTY_SENTINEL)
             if ret is not self.EMPTY_SENTINEL:

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_plugin_utils.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_plugin_utils.py
@@ -201,7 +201,7 @@ class PluginManager(object):
 
     def change_variable(self, frame, attr, expression, scope=None):
         for plugin in self.active_plugins:
-            ret = plugin.change_variable(frame, attr, expression, self.EMPTY_SENTINEL)
+            ret = plugin.change_variable(frame, attr, expression, self.EMPTY_SENTINEL, scope)
             if ret is not self.EMPTY_SENTINEL:
                 return ret
 

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_suspended_frames.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_suspended_frames.py
@@ -200,7 +200,7 @@ class _ObjectVariable(_AbstractVariable):
 
         return children_variables
 
-    def change_variable(self, name, value, py_db, fmt=None):
+    def change_variable(self, name, value, py_db, fmt=None, scope: ScopeRequest | None=None):
         children_variable = self.get_child_variable_named(name)
         if children_variable is None:
             return None
@@ -257,7 +257,6 @@ class _FrameVariable(_AbstractVariable):
 
     def change_variable(self, name, value, py_db, fmt=None, scope: ScopeRequest | None=None):
         frame = self.frame
-
         pydevd_vars.change_attr_expression(frame, name, value, py_db, scope=scope)
         return self.get_child_variable_named(name, fmt=fmt, scope=scope)
 

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_suspended_frames.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_suspended_frames.py
@@ -11,7 +11,7 @@ from _pydevd_bundle import pydevd_vars
 from _pydev_bundle.pydev_imports import Exec
 from _pydevd_bundle.pydevd_frame_utils import FramesList
 from _pydevd_bundle.pydevd_utils import ScopeRequest, DAPGrouper, Timer
-from typing import Optional, Union
+from typing import Optional
 
 
 class _AbstractVariable(object):
@@ -200,7 +200,7 @@ class _ObjectVariable(_AbstractVariable):
 
         return children_variables
 
-    def change_variable(self, name, value, py_db, fmt=None, scope: Union[ScopeRequest, None]=None):
+    def change_variable(self, name, value, py_db, fmt=None, scope: Optional[ScopeRequest]=None):
         children_variable = self.get_child_variable_named(name)
         if children_variable is None:
             return None
@@ -255,7 +255,7 @@ class _FrameVariable(_AbstractVariable):
         self._register_variable = register_variable
         self._register_variable(self)
 
-    def change_variable(self, name, value, py_db, fmt=None, scope: Union[ScopeRequest, None]=None):
+    def change_variable(self, name, value, py_db, fmt=None, scope: Optional[ScopeRequest]=None):
         frame = self.frame
         pydevd_vars.change_attr_expression(frame, name, value, py_db, scope=scope)
         return self.get_child_variable_named(name, fmt=fmt, scope=scope)

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_suspended_frames.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_suspended_frames.py
@@ -255,12 +255,11 @@ class _FrameVariable(_AbstractVariable):
         self._register_variable = register_variable
         self._register_variable(self)
 
-    def change_variable(self, name, value, py_db, fmt=None):
+    def change_variable(self, name, value, py_db, fmt=None, scope: ScopeRequest | None=None):
         frame = self.frame
 
-        pydevd_vars.change_attr_expression(frame, name, value, py_db)
-
-        return self.get_child_variable_named(name, fmt=fmt)
+        pydevd_vars.change_attr_expression(frame, name, value, py_db, scope=scope)
+        return self.get_child_variable_named(name, fmt=fmt, scope=scope)
 
     @silence_warnings_decorator
     @overrides(_AbstractVariable.get_children_variables)

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_suspended_frames.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_suspended_frames.py
@@ -11,7 +11,7 @@ from _pydevd_bundle import pydevd_vars
 from _pydev_bundle.pydev_imports import Exec
 from _pydevd_bundle.pydevd_frame_utils import FramesList
 from _pydevd_bundle.pydevd_utils import ScopeRequest, DAPGrouper, Timer
-from typing import Optional
+from typing import Optional, Union
 
 
 class _AbstractVariable(object):
@@ -200,7 +200,7 @@ class _ObjectVariable(_AbstractVariable):
 
         return children_variables
 
-    def change_variable(self, name, value, py_db, fmt=None, scope: ScopeRequest | None=None):
+    def change_variable(self, name, value, py_db, fmt=None, scope: Union[ScopeRequest, None]=None):
         children_variable = self.get_child_variable_named(name)
         if children_variable is None:
             return None
@@ -255,7 +255,7 @@ class _FrameVariable(_AbstractVariable):
         self._register_variable = register_variable
         self._register_variable(self)
 
-    def change_variable(self, name, value, py_db, fmt=None, scope: ScopeRequest | None=None):
+    def change_variable(self, name, value, py_db, fmt=None, scope: Union[ScopeRequest, None]=None):
         frame = self.frame
         pydevd_vars.change_attr_expression(frame, name, value, py_db, scope=scope)
         return self.get_child_variable_named(name, fmt=fmt, scope=scope)

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_vars.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_vars.py
@@ -20,7 +20,7 @@ import inspect
 from _pydevd_bundle.pydevd_daemon_thread import PyDBDaemonThread
 from _pydevd_bundle.pydevd_save_locals import update_globals_and_locals
 from functools import lru_cache
-from typing import Union
+from typing import Optional
 
 SENTINEL_VALUE = []
 
@@ -596,7 +596,7 @@ def evaluate_expression(py_db, frame, expression, is_exec):
         del frame
 
 
-def change_attr_expression(frame, attr, expression, dbg, value=SENTINEL_VALUE, /, scope: Union[ScopeRequest, None]=None):
+def change_attr_expression(frame, attr, expression, dbg, value=SENTINEL_VALUE, /, scope: Optional[ScopeRequest]=None):
     """Changes some attribute in a given frame."""
     if frame is None:
         return

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_vars.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_vars.py
@@ -20,6 +20,7 @@ import inspect
 from _pydevd_bundle.pydevd_daemon_thread import PyDBDaemonThread
 from _pydevd_bundle.pydevd_save_locals import update_globals_and_locals
 from functools import lru_cache
+from typing import Union
 
 SENTINEL_VALUE = []
 
@@ -595,7 +596,7 @@ def evaluate_expression(py_db, frame, expression, is_exec):
         del frame
 
 
-def change_attr_expression(frame, attr, expression, dbg, value=SENTINEL_VALUE, /, scope: ScopeRequest | None=None):
+def change_attr_expression(frame, attr, expression, dbg, value=SENTINEL_VALUE, /, scope: Union[ScopeRequest, None]=None):
     """Changes some attribute in a given frame."""
     if frame is None:
         return

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_vars.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_vars.py
@@ -15,7 +15,7 @@ import sys  # @Reimport
 from _pydev_bundle._pydev_saved_modules import threading
 from _pydevd_bundle import pydevd_save_locals, pydevd_timeout, pydevd_constants
 from _pydev_bundle.pydev_imports import Exec, execfile
-from _pydevd_bundle.pydevd_utils import to_string
+from _pydevd_bundle.pydevd_utils import to_string, ScopeRequest
 import inspect
 from _pydevd_bundle.pydevd_daemon_thread import PyDBDaemonThread
 from _pydevd_bundle.pydevd_save_locals import update_globals_and_locals
@@ -595,10 +595,14 @@ def evaluate_expression(py_db, frame, expression, is_exec):
         del frame
 
 
-def change_attr_expression(frame, attr, expression, dbg, value=SENTINEL_VALUE):
+def change_attr_expression(frame, attr, expression, dbg, value=SENTINEL_VALUE, /, scope: ScopeRequest | None=None):
     """Changes some attribute in a given frame."""
     if frame is None:
         return
+
+    if scope is not None:
+        assert isinstance(scope, ScopeRequest)
+        scope = scope.scope
 
     try:
         expression = expression.replace("@LINE@", "\n")
@@ -608,13 +612,15 @@ def change_attr_expression(frame, attr, expression, dbg, value=SENTINEL_VALUE):
             if result is not dbg.plugin.EMPTY_SENTINEL:
                 return result
 
-        if attr[:7] == "Globals":
-            attr = attr[8:]
+        if attr[:7] == "Globals" or scope == "globals":
+            attr = attr[8:] if attr.startswith("Globals") else attr
             if attr in frame.f_globals:
                 if value is SENTINEL_VALUE:
                     value = eval(expression, frame.f_globals, frame.f_locals)
                 frame.f_globals[attr] = value
                 return frame.f_globals[attr]
+            else:
+                raise VariableError("Attribute %s not found in globals" % attr)
         else:
             if "." not in attr:  # i.e.: if we have a '.', we're changing some attribute of a local var.
                 if pydevd_save_locals.is_save_locals_available():
@@ -631,8 +637,9 @@ def change_attr_expression(frame, attr, expression, dbg, value=SENTINEL_VALUE):
             Exec("%s=%s" % (attr, expression), frame.f_globals, frame.f_locals)
             return result
 
-    except Exception:
-        pydev_log.exception()
+    except Exception as e:
+        pydev_log.exception(e)
+    
 
 
 MAXIMUM_ARRAY_SIZE = 100

--- a/src/debugpy/_vendored/pydevd/pydevd_plugins/django_debug.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_plugins/django_debug.py
@@ -427,7 +427,7 @@ class DjangoTemplateSyntaxErrorFrame(object):
         self.f_trace = None
 
 
-def change_variable(frame, attr, expression, default):
+def change_variable(frame, attr, expression, default, scope=None):
     if isinstance(frame, DjangoTemplateFrame):
         result = eval(expression, frame.f_globals, frame.f_locals)
         frame._change_variable(attr, result)

--- a/src/debugpy/_vendored/pydevd/pydevd_plugins/django_debug.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_plugins/django_debug.py
@@ -430,7 +430,7 @@ class DjangoTemplateSyntaxErrorFrame(object):
 def change_variable(frame, attr, expression, default, scope=None):
     if isinstance(frame, DjangoTemplateFrame):
         result = eval(expression, frame.f_globals, frame.f_locals)
-        frame._change_variable(attr, result)
+        frame._change_variable(attr, result, scope=scope)
         return result
     return default
 

--- a/src/debugpy/_vendored/pydevd/pydevd_plugins/jinja2_debug.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_plugins/jinja2_debug.py
@@ -249,7 +249,7 @@ class Jinja2TemplateSyntaxErrorFrame(object):
         self.f_trace = None
 
 
-def change_variable(frame, attr, expression, default):
+def change_variable(frame, attr, expression, default, scope=None):
     if isinstance(frame, Jinja2TemplateFrame):
         result = eval(expression, frame.f_globals, frame.f_locals)
         frame._change_variable(frame.f_back, attr, result)

--- a/src/debugpy/_vendored/pydevd/pydevd_plugins/jinja2_debug.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_plugins/jinja2_debug.py
@@ -252,7 +252,7 @@ class Jinja2TemplateSyntaxErrorFrame(object):
 def change_variable(frame, attr, expression, default, scope=None):
     if isinstance(frame, Jinja2TemplateFrame):
         result = eval(expression, frame.f_globals, frame.f_locals)
-        frame._change_variable(frame.f_back, attr, result)
+        frame._change_variable(frame.f_back, attr, result, scope=scope)
         return result
     return default
 

--- a/src/debugpy/_vendored/pydevd/tests_python/resources/_debugger_case_globals.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/resources/_debugger_case_globals.py
@@ -9,4 +9,5 @@ class SomeClass(object):
 
 if __name__ == '__main__':
     SomeClass().method()
+    print('second breakpoint')
     print('TEST SUCEEDED')


### PR DESCRIPTION
In this issue:
https://github.com/microsoft/debugpy/issues/1857

The user is trying to assign the global 'c' to a new value while inside of a function. Since the variable is listed under 'globals', you'd think this would just work.

Internally we don't actually assign it to globals unless the user types `globals()['c']=value`, but that doesn't really make sense from the variables panel.

I found that the scope of the variable is passed in the `setVariables` request, so we can use that to determine if the variable was originally a global or not and assign it to the correct scope.

I tested this with Pydevd's test automation and by using VS code.

Addresses https://github.com/microsoft/debugpy/issues/1857