### PR TITLE
add debugpy-adapter entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,6 +196,11 @@ if __name__ == "__main__":
         has_ext_modules=lambda: True,
         cmdclass=cmds,
         # allow the user to call "debugpy" instead of "python -m debugpy"
-        entry_points={"console_scripts": ["debugpy = debugpy.server.cli:main"]},
+        entry_points={
+            "console_scripts": [
+                "debugpy = debugpy.server.cli:main",
+                "debugpy-adapter = debugpy.adapter.__main__:main",
+            ],
+        },
         **extras
     )

--- a/src/debugpy/adapter/__main__.py
+++ b/src/debugpy/adapter/__main__.py
@@ -13,7 +13,9 @@ import sys
 # and should be imported locally inside main() instead.
 
 
-def main(args):
+def main():
+    args = _parse_argv(sys.argv)
+
     # If we're talking DAP over stdio, stderr is not guaranteed to be read from,
     # so disable it to avoid the pipe filling and locking up. This must be done
     # as early as possible, before the logging module starts writing to it.
@@ -230,4 +232,4 @@ if __name__ == "__main__":
         # the default "C" locale if so.
         pass
 
-    main(_parse_argv(sys.argv))
+    main()


### PR DESCRIPTION
so the adapter can also be launched inside a venv even though debugpy is not installed in the venv.

ref #1868 