### PR TITLE
feat: add monkey_patch_os for posix_spawnp

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydev_bundle/pydev_monkey.py
+++ b/src/debugpy/_vendored/pydevd/_pydev_bundle/pydev_monkey.py
@@ -13,7 +13,6 @@ from _pydevd_bundle.pydevd_constants import (
     DebugInfoHolder,
     PYDEVD_USE_SYS_MONITORING,
     IS_PY313_OR_GREATER,
-    IS_PY38_OR_GREATER,
 )
 from _pydev_bundle import pydev_log
 from contextlib import contextmanager
@@ -1023,7 +1022,7 @@ def patch_new_process_functions():
     monkey_patch_os("spawnvpe", create_spawnve)
     monkey_patch_os("posix_spawn", create_posix_spawn)
 
-    if IS_PY38_OR_GREATER and not IS_WINDOWS:
+    if not IS_WINDOWS:
         monkey_patch_os("posix_spawnp", create_posix_spawn)
 
     if not IS_JYTHON:

--- a/src/debugpy/_vendored/pydevd/_pydev_bundle/pydev_monkey.py
+++ b/src/debugpy/_vendored/pydevd/_pydev_bundle/pydev_monkey.py
@@ -13,6 +13,7 @@ from _pydevd_bundle.pydevd_constants import (
     DebugInfoHolder,
     PYDEVD_USE_SYS_MONITORING,
     IS_PY313_OR_GREATER,
+    IS_PY38_OR_GREATER,
 )
 from _pydev_bundle import pydev_log
 from contextlib import contextmanager
@@ -1021,6 +1022,9 @@ def patch_new_process_functions():
     monkey_patch_os("spawnvp", create_spawnv)
     monkey_patch_os("spawnvpe", create_spawnve)
     monkey_patch_os("posix_spawn", create_posix_spawn)
+
+    if IS_PY38_OR_GREATER and not IS_WINDOWS:
+        monkey_patch_os("posix_spawnp", create_posix_spawn)
 
     if not IS_JYTHON:
         if not IS_WINDOWS:


### PR DESCRIPTION
Add monkey_patch_os for posix_spawnp. Currently only an existing monkey patch for posix_spawn, but would like to add one for posix_spawnp as well. This would allow more users to use debugpy for debugging applications w/ multiprocess architecture.