### PR TITLE
Do not write to stdout on debugging

### DIFF
--- a/src/debugpy/_vendored/pydevd/pydev_ipython/matplotlibtools.py
+++ b/src/debugpy/_vendored/pydevd/pydev_ipython/matplotlibtools.py
@@ -140,11 +140,11 @@ def activate_matplotlib(enable_gui_function):
     if is_interactive:
         enable_gui_function(gui)
         if not matplotlib.is_interactive():
-            sys.stdout.write("Backend %s is interactive backend. Turning interactive mode on.\n" % backend)
+            sys.stderr.write("Backend %s is interactive backend. Turning interactive mode on.\n" % backend)
         matplotlib.interactive(True)
     else:
         if matplotlib.is_interactive():
-            sys.stdout.write("Backend %s is non-interactive backend. Turning interactive mode off.\n" % backend)
+            sys.stderr.write("Backend %s is non-interactive backend. Turning interactive mode off.\n" % backend)
         matplotlib.interactive(False)
     patch_use(enable_gui_function)
     patch_is_interactive()


### PR DESCRIPTION
Write to stderr instead of stdout when changing Matplotlib interactivity. Otherwise the doctests will fail when debugging them.

I tested this by changing it manually on my VSCode instance 😁.