### PR TITLE
dap: Ensure cwd is present in runInTerminal request

### DIFF
--- a/src/debugpy/adapter/launchers.py
+++ b/src/debugpy/adapter/launchers.py
@@ -148,6 +148,7 @@ def spawn_debuggee(
                 "title": console_title,
                 "args": cmdline,
                 "env": env,
+                "cwd": ""
             }
             if cwd is not None:
                 request_args["cwd"] = cwd


### PR DESCRIPTION
Per https://microsoft.github.io/debug-adapter-protocol/specification, `runInTerminalRequestArguments.cwd` is a mandatory property (although it can be left empty).