### PR TITLE
Fix round-robin CI script when state issue has no assignees

### DIFF
--- a/.github/workflows/round-robin.yml
+++ b/.github/workflows/round-robin.yml
@@ -24,7 +24,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             });
-            return issue.data.assignees[0].login || '';
+            return (issue.data.assignees && issue.data.assignees[0].login) || '';
       - name: Dump last assigned
         env:
           LAST_ASSIGNED: ${{ steps.assigned.outputs.result }}


### PR DESCRIPTION
When filing an issue, I noticed this script currently fails

https://github.com/microsoft/debugpy/actions/runs/16282872571