### PR TITLE
Update CODEOWNERS to remove a reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # in the repository, i.e. bar/baz will match /bar/baz and /foo/bar/baz.
 
 # The default owners for everything that is not overridden by specific patterns below.
-*   @microsoft/debugpy-CodeReviewers @microsoft/pyrx-admins
+*  @microsoft/pyrx-admins


### PR DESCRIPTION
Removed @microsoft/debugpy-CodeReviewers from default owners.