### PR TITLE
Use sys.remote_exec() to attach to pid, if available

### DIFF
--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -37,6 +37,7 @@ Usage: debugpy --listen | --connect
                [--log-to <path>] [--log-to-stderr]
                [--parent-session-pid <pid>]]
                [--adapter-access-token <token>]
+               [--disable-sys-remote-exec]]
                {1}
                [<arg>]...
 """.format(


### PR DESCRIPTION
Use PEP768 code injection on Python>=3.14.

Profiling shows that this is approximately 4x faster than pydevd's gdb injection:

```
======================================================================
RESULTS SUMMARY
======================================================================

sys.remote_exec (Python 3.14+ / PEP 768):
  Successful runs: 20/20
  Average time:    0.4589s
  Min time:        0.4178s
  Max time:        0.5595s

pydevd injection (--disable-sys-remote-exec):
  Successful runs: 20/20
  Average time:    2.0423s
  Min time:        1.9090s
  Max time:        2.5464s

----------------------------------------------------------------------
COMPARISON:
  sys.remote_exec is 4.45x faster than pydevd injection
  Time saved per attach: 1.5834s
----------------------------------------------------------------------
```