### PR TITLE
Add Devcontainer Spec

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/devcontainers/python:3.14
+
+# Install GDB
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gdb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch to non-root user and install Python packages
+USER vscode
+RUN python -m pip install black flake8 tox

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "debugpy Development",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
I'm taking a stab at adding UNIX domain socket support to debugpy. Since I prefer to work in devcontainers, I added a spec.

Feel free to reject this MR if you don't think it's appropriate. Also let me know if I should add in all Python versions so the whole test matrix can be run.

Once the container is started, the tests can be run using `python -m tox -e py314 --develop`