### PR TITLE
Try a different way to suppress binskim problems

### DIFF
--- a/.gdn/global.gdnsuppress
+++ b/.gdn/global.gdnsuppress
@@ -1,0 +1,29 @@
+
+{
+  "58a87fd4d7371ece41c06d9d8ef960a90be375cf25621fdddc0f69ed70a8b6f4": {
+    "signature": "58a87fd4d7371ece41c06d9d8ef960a90be375cf25621fdddc0f69ed70a8b6f4",
+    "alternativeSignatures": [
+      "86f6ccbed316821fbcca7e2f0daafcc164b6df645a491d850e1ac16b39eb747e"
+    ],
+    "target": "pydevd/inject_dll_amd64.exe",
+    "memberOf": [
+      "default"
+    ],
+    "tool": "binskim",
+    "ruleId": "BA2007",
+    "createdDate": "2026-01-20 21:21:03Z"
+  },
+  "2b82071ec3bb1a8e80b1615d79febb69084008a4b5a19e66dbeac590b39d4c55": {
+    "signature": "2b82071ec3bb1a8e80b1615d79febb69084008a4b5a19e66dbeac590b39d4c55",
+    "alternativeSignatures": [
+      "3e5a1d789a42983ae1541ba91e20f10f388886a5ba62833ec66e0a358adc1174"
+    ],
+    "target": "pydevd/inject_dll_x86.exe",
+    "memberOf": [
+      "default"
+    ],
+    "tool": "binskim",
+    "ruleId": "BA2007",
+    "createdDate": "2026-01-20 21:21:03Z"
+  }
+}


### PR DESCRIPTION
Binskim errors related to this are still happening:

```
##[error]9. BinSkim Error BA2007 - File: pydevd/inject_dll_amd64.exe.  
Signature: 58a87fd4d7371ece41c06d9d8ef960a90be375cf25621fdddc0f69ed70a8b6f4
Tool: BinSkim: Rule: BA2007 (EnableCriticalCompilerWarnings). https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2007EnableCriticalCompilerWarnings
'inject_dll_amd64.exe' disables compiler warning(s) which are required by policy. A compiler warning is typically required if it has a high likelihood of flagging memory corruption, information disclosure, or double-free vulnerabilities.
To resolve this issue, enable the indicated warning(s) by removing /Wxxxx switches (where xxxx is a warning id indicated here) from your command line, and resolve any warnings subsequently raised during compilation.
For VC projects check ItemDefinitionGroup - ClCompile - DisableSpecificWarnings property.
An example compiler command line triggering this check was: -FC -MT -c -Zc:wchar_t- -Zl -Zp8 -Gy -W3 -EHs -EHc -GR- -GF -GS -kernel -Ox -Os -Z7 -we4146 -we4308 -we4509 -we4510 -we4532 -we4533 -we4610 -we4700 -we4701 -we4703 -we4789 -wd4146 -wd4701 -wd4703 -Zc:alignedNew- -w15043 -funcoverride:_guard_check_icall -ZH:SHA_256 -wd4986 -wd4471 -wd4369 -wd4309 -wd4754 -wd4427 -Wv:19.24 -Zc:tlsGuards- -wl4002 -wl4003 -wl4005 -wl4006 -wl4007 -wl4010 -wl4013 -wl4015 -wl4018 -wl4020 -wl4022 -wl4024 -wl4025 -wl4026 -wl4027 -wl4028 -wl4029 -wl4030 -wl4031 -wl4033 -wl4034 -wl4036 -wl4038 -wl4041 -wl4042 -wl4045 -wl4047 -wl4048 -wl4049 -wl4056 -wl4067 -wl4068 -wl4073 -wl4074 -wl4075 -wl4076 -wl4077 -wl4079 -wl4080 -wl4081 -wl4083 -wl4085 -wl4086 -wl4087 -wl4088 -wl4089 -wl4090 -wl4094 -wl4096 -wl4097 -wl4098 -wl4099 -wl4101 -wl4102 -wl4109 -wl4112 -wl4113 -wl4114 -wl4115 -wl4116 -wl4119 -wl4120 -wl4122 -wl4124 -wl4129 -wl4133 -wl4138 -wl4141 -wl4142 -wl4143 -wl4144 -wl4145 -wl4150 -wl4153 -wl4154 -wl4155 -wl4156 -wl4158 -wl4159 -wl4160 -wl4161 -wl4162 -wl4163 -wl4164 -wl4166 -wl4167 -wl4168 -wl4172 -wl4174 -wl4175 -wl4176 -wl4177 -wl4178 -wl4182 -wl4183 -wl4190 -wl4192 -wl4237 -wl4243 -wl4244 -wl4250 -wl4251 -wl4267 -wl4269 -wl4272 -wl4273 -wl4275 -wl4276 -wl4278 -wl4280 -wl4281 -wl4282 -wl4283 -wl4285 -wl4286 -wl4291 -wl4293 -wl4297 -wl4302 -wl4305 -wl4306 -wl4307 -wl4309 -wl4310 -wl4311 -wl4312 -wl4313 -wl4316 -wl4319 -wl4326 -wl4333 -wl4334 -wl4335 -wl4340 -wl4344 -wl4346 -wl4348 -wl4356 -wl4358 -wl4364 -wl4368 -wl4369 -wl4373 -wl4374 -wl4375 -wl4376 -wl4377 -wl4378 -wl4379 -wl4381 -wl4382 -wl4383 -wl4384 -wl4390 -wl4391 -wl4392 -wl4394 -wl4395 -wl4396 -wl4398 -wl4399 -wl4600 -wl4401 -wl4402 -wl4403 -wl4405 -wl4407 -wl4409 -wl4410 -wl4411 -wl4414 -wl4420 -wl4430 -wl4436 -wl4439 -wl4445 -wl4461 -wl4462 -wl4473 -wl4477 -wl4484 -wl4485 -wl4486 -wl4488 -wl4489 -wl4490 -wl4502 -wl4503 -wl4506 -wl4508 -wl4511 -wl4521 -wl4522 -wl4523 -wl4530 -wl4534 -wl4535 -wl4537 -wl4538 -wl4540 -wl4541 -wl4543 -wl4550 -wl4551 -wl4552 -wl4553 -wl4554 -wl4556 -wl4558 -wl4561 -wl4566 -wl4570 -wl4572 -wl4580 -wl4581 -wl4584 -wl4596 -wl4597 -wl4602 -wl4603 -wl4612 -wl4613 -wl4615 -wl4616 -wl4620 -wl4621 -wl4622 -wl4624 -wl4627 -wl4630 -wl4632 -wl4633 -wl4635 -wl4636 -wl4637 -wl4638 -wl4641 -wl4645 -wl4646 -wl4650 -wl4651 -wl4652 -wl4655 -wl4656 -wl4657 -wl4659 -wl4661 -wl4662 -wl4667 -wl4669 -wl4674 -wl4677 -wl4678 -wl4679 -wl4683 -wl4684 -wl4685 -wl4687 -wl4688 -wl4691 -wl4693 -wl4694 -wl4698 -wl4711 -wl4715 -wl4716 -wl4717 -wl4722 -wl4723 -wl4724 -wl4727 -wl4730 -wl4731 -wl4733 -wl4739 -wl4742 -wl4743 -wl4744 -wl4747 -wl4750 -wl4756 -wl4772 -wl4788 -wl4793 -wl4794 -wl4799 -wl4803 -wl4804 -wl4805 -wl4806 -wl4807 -wl4810 -wl4811 -wl4812 -wl4813 -wl4817 -wl4819 -wl4821 -wl4823 -wl4829 -wl4834 -wl4835 -wl4838 -wl4839 -wl4900 -wl4910 -wl4912 -wl4920 -wl4925 -wl4927 -wl4930 -wl4935 -wl4936 -wl4939 -wl4944 -wl4945 -wl4947 -wl4948 -wl4949 -wl4950 -wl4951 -wl4952 -wl4953 -wl4956 -wl4957 -wl4958 -wl4959 -wl4961 -wl4964 -wl4965 -wl4972 -wl4984 -wl4995 -wl4996 -wl4997 -wl4999 -wl5033 -wl5037 -wl5046 -wl5050 -wl5055 -wl5056 -wl5105 -wl5208 -Gw -Zc:checkGwOdr -wd4316 -wd4973 -Brepro -Zc:sizedDealloc- -Qspectre -wd5045 -guard:cf -wd4425 -we4001 -we4202 -we4203 -we4204 -we4205 -we4212 -we4214 -we4215 -we4216 -we4221 -we4223 -we4224 -we4226 -we4228 -we4233 -we4234 -we4240 -we4288 -we4289 -we4353 -we4480 -we4482 -we4775 -we4867 -we4987 -we5047 -we5200 -we5201 -we5202 -we5203 -we5227 -we5228 -we5229 -we5230 -we4008 -we4066 -we4157 -we4181 -we4185 -we4186 -we4187 -we4194 -we4195 -we4197 -we4227 -we4230 -we4258 -we4274 -we4277 -we4290 -we4325 -we4329 -we4330 -we4357 -we4359 -we4393 -we4397 -we4404 -we4406 -we4416 -we4417 -we4418 -we4440 -we4441 -we4470 -we4494 -we4518 -we4526 -we4544 -we4606 -we4618 -we4653 -we4648 -we4649 -we4689 -we4728 -we4771 -we4846 -we4847 -we4856 -we4926 -we4929 -we4955 -we4966 -we4970 -we4983 -we5051 -we5057 -we5210 -we5234 -we5235 -we5236 -we5237 -we5238 -wl4001 -wl4202 -wl4203 -wl4204 -wl4205 -wl4212 -wl4214 -wl4215 -wl4216 -wl4221 -wl4223 -wl4224 -wl4226 -wl4228 -wl4233 -wl4234 -wl4240 -wl4288 -wl4289 -wl4353 -wl4480 -wl4482 -wl4775 -wl4867 -wl4987 -wl5047 -wl5200 -wl5201 -wl5202 -wl5203 -wl5227 -wl5228 -wl5229 -wl5230 -wl4008 -wl4066 -wl4157 -wl4181 -wl4185 -wl4186 -wl4187 -wl4194 -wl4195 -wl4197 -wl4227 -wl4230 -wl4258 -wl4274 -wl4277 -wl4290 -wl4325 -wl4329 -wl4330 -wl4357 -wl4359 -wl4393 -wl4397 -wl4404 -wl4406 -wl4416 -wl4417 -wl4418 -wl4440 -wl4441 -wl4470 -wl4494 -wl4518 -wl4526 -wl4544 -wl4606 -wl4618 -wl4653 -wl4648 -wl4649 -wl4689 -wl4728 -wl4771 -wl4846 -wl4847 -wl4856 -wl4926 -wl4929 -wl4955 -wl4966 -wl4970 -wl4983 -wl5051 -wl5057 -wl5210 -wl5234 -wl5235 -wl5236 -wl5237 -wl5238 -wl4146 -wl4308 -wl4509 -wl4510 -wl4532 -wl4533 -wl4610 -wl4700 -wl4701 -wl4703 -wl4789 -wl4091 -wl4117 -wl4152 -wl4180 -wl4200 -wl4201 -wl4206 -wl4207 -wl4208 -wl4210 -wl4211 -wl4213 -wl4218 -wl4229 -wl4232 -wl4235 -wl4238 -wl4239 -wl4456 -wl4457 -wl4458 -wl4459 -wl4481 -wl4495 -wl4496 -wl4497 -wl4498 -wl4499 -wl4654 -wl4768 -wl4845 -wl5029 -wl5102 -wl5240 -TC -X
Modules triggering this check were:
abort.obj (libucrt.lib) [Explicitly disabled warnings: 4146]
```

this is because of an internal tool. Adding the suppression here will hopefully fix the issue.