### PR TITLE
Display dlerror output if dlopen fails

### DIFF
--- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
+++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
@@ -467,6 +467,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
     cmd.extend(
         [
             "--eval-command='call (void*)dlopen(\"%s\", 2)'" % target_dll,
+            "--eval-command='call (char*)dlerror()'",
             "--eval-command='sharedlibrary %s'" % target_dll_name,
             "--eval-command='call (int)DoAttach(%s, \"%s\", %s)'" % (is_debug, python_code, show_debug_info),
         ]


### PR DESCRIPTION
This helps debug setup issues, for example glibc versioning problems.