### PR TITLE
Prevent invalid scopes request from crashing debug session

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -1109,10 +1109,13 @@ class PyDevJsonCommandProcessor(object):
         frame_id = request.arguments.frameId
 
         variables_reference = frame_id
-        scopes = [
-            Scope("Locals", ScopeRequest(int(variables_reference), "locals"), False, presentationHint="locals"),
-            Scope("Globals", ScopeRequest(int(variables_reference), "globals"), False),
-        ]
+        try:
+            scopes = [
+                Scope("Locals", ScopeRequest(int(variables_reference), "locals"), False, presentationHint="locals"),
+                Scope("Globals", ScopeRequest(int(variables_reference), "globals"), False),
+            ]
+        except Exception:
+            scopes = []
         body = ScopesResponseBody(scopes)
         scopes_response = pydevd_base_schema.build_response(request, kwargs={"body": body})
         return NetCommand(CMD_RETURN, 0, scopes_response, is_json=True)

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -1114,7 +1114,11 @@ class PyDevJsonCommandProcessor(object):
                 Scope("Locals", ScopeRequest(int(variables_reference), "locals"), False, presentationHint="locals"),
                 Scope("Globals", ScopeRequest(int(variables_reference), "globals"), False),
             ]
+        except (ValueError, TypeError):
+            pydev_log.info("Failed to create scopes for frame id: %s", frame_id)
+            scopes = []
         except Exception:
+            pydev_log.exception("Failed to create scopes for frame id: %s", frame_id)
             scopes = []
         body = ScopesResponseBody(scopes)
         scopes_response = pydevd_base_schema.build_response(request, kwargs={"body": body})

--- a/src/debugpy/_vendored/pydevd/tests_python/test_pydevd_process_net_command_json.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_pydevd_process_net_command_json.py
@@ -1,0 +1,32 @@
+def test_on_scopes_request_with_valid_frame_id():
+    from _pydevd_bundle._debug_adapter import pydevd_schema, pydevd_base_schema
+    from _pydevd_bundle.pydevd_process_net_command_json import PyDevJsonCommandProcessor
+
+    processor = PyDevJsonCommandProcessor(pydevd_base_schema.from_json)
+    request = pydevd_schema.ScopesRequest(pydevd_schema.ScopesArguments(frameId=1))
+
+    result = processor.on_scopes_request(None, request)
+    response = result.as_dict
+
+    assert response["success"] is True
+    scopes = response["body"]["scopes"]
+    assert len(scopes) == 2
+    assert scopes[0]["name"] == "Locals"
+    assert scopes[0]["presentationHint"] == "locals"
+    assert scopes[1]["name"] == "Globals"
+
+
+def test_on_scopes_request_with_invalid_frame_id():
+    from _pydevd_bundle._debug_adapter import pydevd_schema, pydevd_base_schema
+    from _pydevd_bundle.pydevd_process_net_command_json import PyDevJsonCommandProcessor
+
+    processor = PyDevJsonCommandProcessor(pydevd_base_schema.from_json)
+    request = pydevd_schema.ScopesRequest(
+        pydevd_schema.ScopesArguments(frameId="not_a_number")
+    )
+
+    result = processor.on_scopes_request(None, request)
+    response = result.as_dict
+
+    assert response["success"] is True
+    assert response["body"]["scopes"] == []


### PR DESCRIPTION
If an unmapped or non-numeric frameId is sent in a scopes request, int() raises a ValueError that terminates the debug session. Wrap the scope construction in a try/except so that invalid frameIds return an empty scopes list instead, which is valid per the DAP spec.