### PR TITLE
Fix TSA #2816216: suppress Flawfinder false positive on Cython DIGIT_PAIRS_8 memcpy

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_cython.c
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_cython.c
@@ -45633,7 +45633,7 @@ static CYTHON_INLINE PyObject* __Pyx____Pyx_PyUnicode_From_int(int value, Py_ssi
             digit_pos = abs((int)(remaining % (8*8)));
             remaining = (int) (remaining / (8*8));
             dpos -= 2;
-            memcpy(dpos, DIGIT_PAIRS_8 + digit_pos * 2, 2);
+            memcpy(dpos, DIGIT_PAIRS_8 + digit_pos * 2, 2); /* Flawfinder: ignore */
             last_one_off = (digit_pos < 8);
             break;
         case 'd':

--- a/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
+++ b/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
@@ -185,6 +185,8 @@ def build_extension(dir_name, extension_name, target_pydevd_name, force_cython, 
                 c_file_contents = c_file_contents.replace(
                     "            memcpy(dpos, DIGIT_PAIRS_8 + digit_pos * 2, 2);\n",
                     "            memcpy(dpos, DIGIT_PAIRS_8 + digit_pos * 2, 2); /* Flawfinder: ignore */\n",
+                )
+
                 # Suppress Flawfinder false positive (CWE-120/CWE-20) in the
                 # Cython 3.x ModuleStateLookup boilerplate (`__Pyx_State_ConvertFromInterpIdAsIndex`):
                 # `read` is a bounded pointer iterator (not POSIX read()), and the loop is

--- a/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
+++ b/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
@@ -177,6 +177,16 @@ def build_extension(dir_name, extension_name, target_pydevd_name, force_cython, 
                 c_file_contents = c_file_contents.replace(r"_pydevd_bundle\\pydevd_cython.pxd", "_pydevd_bundle/pydevd_cython.pxd")
                 c_file_contents = c_file_contents.replace(r"_pydevd_bundle\\pydevd_cython.pyx", "_pydevd_bundle/pydevd_cython.pyx")
 
+                # Suppress Flawfinder false positive (CWE-120) in the Cython 3.x
+                # CIntToPyUnicode boilerplate (`__Pyx____Pyx_PyUnicode_From_int`): the destination
+                # `dpos` is a stack buffer of size `sizeof(int)*3+2`, and `dpos -= 2` immediately
+                # precedes a 2-byte memcpy from the 128-byte constant table `DIGIT_PAIRS_8`
+                # indexed by `digit_pos * 2` where `digit_pos = abs(remaining % 64)`.
+                c_file_contents = c_file_contents.replace(
+                    "            memcpy(dpos, DIGIT_PAIRS_8 + digit_pos * 2, 2);\n",
+                    "            memcpy(dpos, DIGIT_PAIRS_8 + digit_pos * 2, 2); /* Flawfinder: ignore */\n",
+                )
+
                 with open(c_file, "w") as stream:
                     stream.write(c_file_contents)
 


### PR DESCRIPTION
## Issue

Internal Flawfinder compliance scan flagged a `memcpy` in the Cython-generated `pydevd_cython.c`.

- Work item: [TSA #2816216](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2816216/)
- Rule: `FlawFinder/buffer/memcpy` — *"Does not check for buffer overflows when copying to destination (CWE-120)"*
- File: `src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_cython.c`
- Line: 45636
- AB#2816216

## What Flawfinder reported

```c
memcpy(dpos, DIGIT_PAIRS_8 + digit_pos * 2, 2);
```

inside the Cython 3.x integer-to-string helper `__Pyx____Pyx_PyUnicode_From_int` (case `'o'` of the format-char switch).

## Why this is a false positive

Flawfinder flags every `memcpy()` call by default because it can't statically prove the size argument is safe. In this case all three arguments are provably bounded:

1. **Destination is in bounds.** The buffer is a local stack array declared a few lines above: `char digits[sizeof(int)*3+2]`. Each iteration does `dpos -= 2` *before* the 2-byte copy, and the enclosing `do/while` loop divides `remaining` by 64 each pass, so it iterates at most ⌈log₆₄(INT_MAX)⌉ times — well within the allocated buffer.
2. **Source is in bounds.** `DIGIT_PAIRS_8` is a 128-byte compile-time constant table (64 pairs × 2 ASCII chars). `digit_pos = abs(remaining % 64)`, so the offset `digit_pos * 2` is in `[0, 126]` — the 2-byte read is always inside the table.
3. **Size is a compile-time literal `2`.** No way for it to be wrong.

This is Cython runtime boilerplate that mirrors the same pattern used in CPython itself.

## Fix

1. Add `/* Flawfinder: ignore */` to the flagged line. This is the documented Flawfinder suppression token (see `flawfinder --help`).
2. Add a corresponding `c_file_contents.replace(...)` to the existing post-processing block in `setup_pydevd_cython.py` so the suppression is automatically re-applied if Cython is re-run to regenerate the `.c` file.

The annotation is a C block comment — equivalent to whitespace at the lexer level, with zero effect on compiled output or runtime behavior.

## Verification

Ran Flawfinder 2.0.20 locally against the modified file:

| Run | Hits at line 45636 |
|---|---|
| Default | **0** ✅ |
| `flawfinder --neverignore` (suppressions disabled) | 1 (the originally reported warning reappears) |

The originally flagged warning is silenced, and the positive control with `--neverignore` confirms the suppression is what's silencing it.

## Risk

Zero behavioral change. The `.c` file edit is a comment; the `setup_pydevd_cython.py` edit is a `str.replace()` that is a no-op if the matched text is absent (so it's safe even if Cython upstream changes its output).
