### PR TITLE
Fix TSA #2816217: suppress Flawfinder false positive on Cython JoinPyUnicode memcpy

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.c
+++ b/src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.c
@@ -38185,7 +38185,7 @@ static PyObject* __Pyx_PyUnicode_Join(PyObject** values, Py_ssize_t value_count,
         ukind = __Pyx_PyUnicode_KIND(uval);
         udata = __Pyx_PyUnicode_DATA(uval);
         if (ukind == result_ukind) {
-            memcpy((char *)result_udata + (char_pos << kind_shift), udata, (size_t) (ulength << kind_shift));
+            memcpy((char *)result_udata + (char_pos << kind_shift), udata, (size_t) (ulength << kind_shift)); /* Flawfinder: ignore */
         } else {
             #if PY_VERSION_HEX >= 0x030d0000
             if (unlikely(PyUnicode_CopyCharacters(result_uval, char_pos, uval, 0, ulength) < 0)) goto bad;

--- a/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
+++ b/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
@@ -177,6 +177,17 @@ def build_extension(dir_name, extension_name, target_pydevd_name, force_cython, 
                 c_file_contents = c_file_contents.replace(r"_pydevd_bundle\\pydevd_cython.pxd", "_pydevd_bundle/pydevd_cython.pxd")
                 c_file_contents = c_file_contents.replace(r"_pydevd_bundle\\pydevd_cython.pyx", "_pydevd_bundle/pydevd_cython.pyx")
 
+                # Suppress Flawfinder false positive (CWE-120) in the Cython 3.x
+                # `__Pyx_PyUnicode_Join` boilerplate: the destination `result_uval` was just
+                # allocated via `PyUnicode_New(result_ulength, max_char)`, and the immediately
+                # preceding `(PY_SSIZE_T_MAX >> kind_shift) - ulength < char_pos` check guards
+                # against char_pos+ulength overflow before the memcpy. The size argument is
+                # `ulength << kind_shift` which is bounded by the pre-allocated buffer length.
+                c_file_contents = c_file_contents.replace(
+                    "            memcpy((char *)result_udata + (char_pos << kind_shift), udata, (size_t) (ulength << kind_shift));\n",
+                    "            memcpy((char *)result_udata + (char_pos << kind_shift), udata, (size_t) (ulength << kind_shift)); /* Flawfinder: ignore */\n",
+                )
+
                 with open(c_file, "w") as stream:
                     stream.write(c_file_contents)
 

--- a/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
+++ b/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
@@ -186,6 +186,8 @@ def build_extension(dir_name, extension_name, target_pydevd_name, force_cython, 
                 c_file_contents = c_file_contents.replace(
                     "            memcpy((char *)result_udata + (char_pos << kind_shift), udata, (size_t) (ulength << kind_shift));\n",
                     "            memcpy((char *)result_udata + (char_pos << kind_shift), udata, (size_t) (ulength << kind_shift)); /* Flawfinder: ignore */\n",
+                )
+
                 # Suppress Flawfinder false positive (CWE-120/CWE-20) in the
                 # Cython 3.x ModuleStateLookup boilerplate (`__Pyx_State_ConvertFromInterpIdAsIndex`):
                 # `read` is a bounded pointer iterator (not POSIX read()), and the loop is


### PR DESCRIPTION
## Issue

Internal Flawfinder compliance scan flagged a `memcpy` in the Cython-generated `_pydevd_sys_monitoring_cython.c`.

- Work item: [TSA #2816217](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2816217/)
- Rule: `FlawFinder/buffer/memcpy` — *"Does not check for buffer overflows when copying to destination (CWE-120)"*
- File: `src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.c`
- Line: 38188
- AB#2816217

## What Flawfinder reported

```c
memcpy((char *)result_udata + (char_pos << kind_shift),
       udata,
       (size_t)(ulength << kind_shift));
```

inside the Cython 3.x string-join helper `__Pyx_PyUnicode_Join` (Cython's implementation of `"".join([...])`).

## Why this is a false positive

Flawfinder flags every `memcpy()` because the size argument here is a variable (`ulength << kind_shift`) rather than a constant. But the surrounding code makes the copy provably safe:

1. **Destination is pre-allocated to the exact total length.** A few lines above:
   ```c
   result_uval = PyUnicode_New(result_ulength, max_char);
   result_udata = PyUnicode_DATA(result_uval);
   ```
   `result_ulength` is the sum of all input lengths, computed by the caller.

2. **Overflow is explicitly checked before each `memcpy`.** Two lines above the flagged line:
   ```c
   if (unlikely((PY_SSIZE_T_MAX >> kind_shift) - ulength < char_pos))
       goto overflow;
   ```
   This guards against `char_pos + ulength` exceeding the addressable range. If it would, the code skips the copy and reports an `OverflowError`.

3. **`char_pos` accumulates the same `ulength` values that sized the buffer**, so by induction `char_pos + ulength ≤ result_ulength` at every iteration.

This mirrors CPython's own `str.join()` implementation in `Objects/unicodeobject.c`.

## Fix

1. Add `/* Flawfinder: ignore */` to the flagged line. This is the documented Flawfinder suppression token (see `flawfinder --help`).
2. Add a corresponding `c_file_contents.replace(...)` to the existing post-processing block in `setup_pydevd_cython.py` so the suppression is automatically re-applied if Cython is re-run to regenerate the `.c` file.

The annotation is a C block comment — equivalent to whitespace at the lexer level, with zero effect on compiled output or runtime behavior.

## Verification

Ran Flawfinder 2.0.20 locally against the modified file:

| Run | Hits at line 38188 |
|---|---|
| Default | **0** ✅ |
| `flawfinder --neverignore` (suppressions disabled) | 1 (the originally reported warning reappears) |

The originally flagged warning is silenced, and the positive control with `--neverignore` confirms the suppression is what's silencing it.

## Risk

Zero behavioral change. The `.c` file edit is a comment; the `setup_pydevd_cython.py` edit is a `str.replace()` that is a no-op if the matched text is absent (so it's safe even if Cython upstream changes its output).
