### PR TITLE
Fix TSA #2816219: suppress Flawfinder false positive on Cython read-loop iterator (_pydevd_sys_monitoring_cython.c)

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.c
+++ b/src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.c
@@ -41994,7 +41994,7 @@ static void __Pyx_State_ConvertFromInterpIdAsIndex(__Pyx_ModuleStateLookupData *
     __Pyx_InterpreterIdAndModule *read = data->table;
     __Pyx_InterpreterIdAndModule *write = data->table;
     __Pyx_InterpreterIdAndModule *end = read + data->count;
-    for (; read<end; ++read) {
+    for (; read<end; ++read) { /* Flawfinder: ignore */
         if (read->module) {
             write->id = read->id;
             write->module = read->module;

--- a/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
+++ b/src/debugpy/_vendored/pydevd/setup_pydevd_cython.py
@@ -177,6 +177,15 @@ def build_extension(dir_name, extension_name, target_pydevd_name, force_cython, 
                 c_file_contents = c_file_contents.replace(r"_pydevd_bundle\\pydevd_cython.pxd", "_pydevd_bundle/pydevd_cython.pxd")
                 c_file_contents = c_file_contents.replace(r"_pydevd_bundle\\pydevd_cython.pyx", "_pydevd_bundle/pydevd_cython.pyx")
 
+                # Suppress Flawfinder false positive (CWE-120/CWE-20) in the
+                # Cython 3.x ModuleStateLookup boilerplate (`__Pyx_State_ConvertFromInterpIdAsIndex`):
+                # `read` is a bounded pointer iterator (not POSIX read()), and the loop is
+                # guarded by `read < end` where `end = read + data->count`.
+                c_file_contents = c_file_contents.replace(
+                    "    for (; read<end; ++read) {\n",
+                    "    for (; read<end; ++read) { /* Flawfinder: ignore */\n",
+                )
+
                 with open(c_file, "w") as stream:
                     stream.write(c_file_contents)
 


### PR DESCRIPTION
## Issue

Internal Flawfinder compliance scan flagged a `for` loop containing the identifier `read` in the Cython-generated `_pydevd_sys_monitoring_cython.c`.

- Work item: [TSA #2816219](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2816219/)
- Rule: `FlawFinder/buffer/read` — *"Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)"*
- File: `src/debugpy/_vendored/pydevd/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.c`
- Line: 41997
- AB#2816219

## What Flawfinder reported

```c
__Pyx_InterpreterIdAndModule *read  = data->table;
__Pyx_InterpreterIdAndModule *write = data->table;
__Pyx_InterpreterIdAndModule *end   = read + data->count;
for (; read<end; ++read) {                  // ← flagged
    if (read->module) {
        write->id     = read->id;
        write->module = read->module;
        ++write;
    }
}
```

This is the Cython 3.x runtime boilerplate function `__Pyx_State_ConvertFromInterpIdAsIndex` (per-interpreter module-state compaction). The same function is emitted into every Cython-generated `.c` file.

## Why this is a false positive

Flawfinder's `buffer/read` rule fires whenever the identifier `read` appears inside a loop, on the assumption it refers to the POSIX `read()` syscall (which can return fewer bytes than requested). Here `read` is a **variable name** — specifically a pointer iterator walking `data->table` — not a syscall.

The loop is provably bounded:
- `end = read + data->count` defines the upper bound.
- The loop condition `read < end` guarantees `read` never advances past the last valid slot.
- `write` only advances on successful copies and always trails `read`, so `write <= read <= end` is invariant.

## Fix

1. Add `/* Flawfinder: ignore */` to the flagged line. This is the documented Flawfinder suppression token (see `flawfinder --help`).
2. Add a corresponding `c_file_contents.replace(...)` to the existing post-processing block in `setup_pydevd_cython.py` so the suppression is automatically re-applied if Cython is re-run to regenerate the `.c` file.

The annotation is a C block comment — equivalent to whitespace at the lexer level, with zero effect on compiled output or runtime behavior.

## Verification

Ran Flawfinder 2.0.20 locally against the modified file:

| Run | Hits at line 41997 |
|---|---|
| Default | **0** ✅ |
| `flawfinder --neverignore` (suppressions disabled) | 2 (the originally reported warning reappears — one hit per `read` token on that line) |

The originally flagged warning is silenced, and the positive control with `--neverignore` confirms the suppression is what's silencing it.

## Risk

Zero behavioral change. The `.c` file edit is a comment; the `setup_pydevd_cython.py` edit is a `str.replace()` that is a no-op if the matched text is absent (so it's safe even if Cython upstream changes its output).

## Related

The same Cython boilerplate appears in two sibling generated files and is tracked separately:
- TSA #2816218 → `pydevd_frame_evaluator.c`
- TSA #2816220 → `pydevd_cython.c`

Each is fixed in its own PR.
