### PR TITLE
Fix PEP 768 code injection SyntaxError when temp path contains backslashes

### DIFF
--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -465,7 +465,7 @@ attach_pid_injected.attach(setup);
                 )
                 tmp_file.write(python_code.encode())
                 tmp_file.write(
-                    """import os;os.remove("{tmp_file_path}");""".format(
+                    """import os;os.remove({tmp_file_path!r});""".format(
                         tmp_file_path=tmp_file_path
                     ).encode()
                 )


### PR DESCRIPTION
On Windows, sys.remote_exec-based (PEP 768) attach-to-PID fails entirely because the temp file path (e.g. C:\Users\...\Temp\tmpXXX) is embedded raw into the injected Python code, where backslashes are misinterpreted as escape sequences.

This fix correctly writes the path with the necessary escape characters.

Fixes #2037