### PR TITLE
Add Dependabot configuration for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot configuration for debugpy.
+#
+# Keeps dependencies up to date and automatically opens pull requests for
+# security (CVE) and version updates. Security updates are always enabled for
+# every ecosystem Dependabot can detect; the entries below also enable regular
+# version updates so dependencies don't drift far enough to accumulate
+# vulnerabilities in the first place.
+#
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Python packages used to run and exercise the test suite.
+  - package-ecosystem: "pip"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      python-test-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,13 @@
 # Dependabot configuration for debugpy.
 #
-# Keeps dependencies up to date and automatically opens pull requests for
-# security (CVE) and version updates. Security updates are always enabled for
-# every ecosystem Dependabot can detect; the entries below also enable regular
-# version updates so dependencies don't drift far enough to accumulate
+# This file configures version updates: Dependabot opens pull requests to keep
+# dependencies current so they don't drift far enough to accumulate
 # vulnerabilities in the first place.
+#
+# NOTE: Security (CVE) updates are NOT enabled by this file. They require the
+# separate "Dependabot security updates" toggle in repo Settings -> Code
+# security. Keeping dependencies current here reduces the surface area for
+# those alerts.
 #
 # Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
@@ -17,7 +20,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-      - "python"
     groups:
       python-test-dependencies:
         patterns:
@@ -31,7 +33,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-      - "github-actions"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

Adds a `.github/dependabot.yml` to enable automated dependency and security (CVE) update pull requests.

This addresses the recurring Component Governance / CVE alerts for the repository by letting Dependabot keep dependencies current and raise security update PRs automatically.

## Ecosystems covered

| Ecosystem | Path | Covers |
|-----------|------|--------|
| `pip` | `/tests` | `tests/requirements.txt` (django, flask, gevent, numpy, requests, etc.) |
| `github-actions` | `/` | Actions used by the workflows (e.g. `actions/checkout`, `github/codeql-action`, `actions/stale`, `actions/github-script`) |

- Weekly schedule, grouped PRs to reduce noise, labels, and a 10 open-PR limit per ecosystem.

## Notes

- This file enables **version updates**. For Dependabot to also open PRs specifically for existing CVE alerts, **Dependabot security updates** must be enabled in repo Settings -> Code security.
- Vendored dependencies under `src/debugpy/_vendored/` and the git components in `cgmanifest.json` (pydevd, bytecode, winappdbg, scandir) are **not** managed by Dependabot and still require manual updates.
