### PR TITLE
Pin secure versions of test dependencies to address CVEs

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 ## Used to run the tests:
 
-pytest
+pytest>=9.0.3  # CVE-2025-71176 (vulnerable <= 9.0.2)
 pytest-xdist
 pytest-cov
 pytest-timeout
@@ -18,7 +18,10 @@ django
 flask
 gevent
 numpy
-requests
+requests>=2.33.0  # CVE-2026-25645 (vulnerable < 2.33.0)
+# urllib3 is pulled in transitively by requests; pin a secure floor for
+# CVE-2026-44431 and CVE-2026-44432 (vulnerable 2.6.0 <= x < 2.7.0).
+urllib3>=2.7.0
 typing_extensions
 
 # Used to build pydevd attach to process binaries:


### PR DESCRIPTION
## Summary

Adds secure minimum-version floors for test dependencies that Component Governance flags as vulnerable. The `Debugpy-Build` pipeline installs `tests/requirements.txt`, and CG scans the resulting (transitive) dependency tree, so the fix belongs here.

## CVEs addressed

| CVE | Package | Severity | Vulnerable | Fixed in |
|-----|---------|----------|-----------|----------|
| CVE-2026-44431 / CVE-2026-44432 | urllib3 | High | 2.6.0 – 2.6.x | 2.7.0 |
| CVE-2026-25645 | requests | Medium | < 2.33.0 | 2.33.0 |
| CVE-2025-71176 | pytest | Medium | <= 9.0.2 | 9.0.3 |

## Changes

- `pytest>=9.0.3`
- `requests>=2.33.0`
- `urllib3>=2.7.0` — pulled in transitively by `requests`, so an explicit floor is needed to force the secure version.

Minimum-version (`>=`) floors are used rather than exact pins so the suite continues to pick up future security releases.

## Verification

`pip install --dry-run` resolves the floors to `pytest 9.1.1`, `requests 2.34.2`, `urllib3 2.7.0` — all patched, no conflicts.

## Notes

- This addresses the pip/Component-Governance alerts only. The vendored components under `src/debugpy/_vendored/pydevd/` are out of scope here and would be handled by a separate pydevd subrepo update.
