### PR TITLE
Update vendored pydevd 3.4.1 -> 3.5.0 (maintenance refresh)

### DIFF
--- a/src/debugpy/_vendored/pydevd/.github/workflows/pydevd-release-manylinux.yml
+++ b/src/debugpy/_vendored/pydevd/.github/workflows/pydevd-release-manylinux.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        include:
+          - runs-on: ubuntu-latest
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
 
@@ -34,9 +38,11 @@ jobs:
         env:
           CIBW_SKIP: pp* cp36-* cp37-*
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_ARCHS: ${{ matrix.arch }}
 
       - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
           
       - name: Upload to PyPI .whl

--- a/src/debugpy/_vendored/pydevd/.gitrepo
+++ b/src/debugpy/_vendored/pydevd/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/fabioz/PyDev.Debugger.git
 	branch = main
-	commit = b5cfeb38d1b11b429e5befe88cb27fcc57fdad12
+	commit = d6bc5f50cc31545fa0f32431a2a88a48f589810a
 	parent = 8ab4ee89e9ae9a926f711904900a27e3c96d43d4
 	method = merge
 	cmdver = 0.4.1

--- a/src/debugpy/_vendored/pydevd/build_tools/build.py
+++ b/src/debugpy/_vendored/pydevd/build_tools/build.py
@@ -110,33 +110,13 @@ def build():
         # set VS100COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\Tools
 
         if "GITHUB_ACTION" not in os.environ:
-            if sys.version_info[:2] in ((3, 6), (3, 7), (3, 8), (3, 9), (3, 10), (3, 11), (3, 12), (3, 13)):
-                FORCE_PYDEVD_VC_VARS = os.environ.get("FORCE_PYDEVD_VC_VARS")
-                if FORCE_PYDEVD_VC_VARS:
-                    env.update(get_environment_from_batch_command([FORCE_PYDEVD_VC_VARS], initial=os.environ.copy()))
-                else:
-                    try:
-                        from setuptools._distutils._msvccompiler import _find_vcvarsall as find_vcvarsall
-                    except Exception:
-                        import setuptools  # We have to import it first for the compiler to be found
-                        from distutils.msvc9compiler import find_vcvarsall
-
-                    vcvarsall = find_vcvarsall(14.0)
-                    if isinstance(vcvarsall, tuple):
-                        vcvarsall = vcvarsall[0]
-                    if vcvarsall is None or not os.path.exists(vcvarsall):
-                        msvc_version = msvc9compiler.get_build_version()
-                        print("msvc_version", msvc_version)
-                        vcvarsall = find_vcvarsall(msvc_version)
-
-                    if vcvarsall is None or not os.path.exists(vcvarsall):
-                        raise RuntimeError("Error finding vcvarsall.")
-
-                    if is_python_64bit():
-                        env.update(get_environment_from_batch_command([vcvarsall, "amd64"], initial=os.environ.copy()))
-                    else:
-                        env.update(get_environment_from_batch_command([vcvarsall, "x86"], initial=os.environ.copy()))
-
+            FORCE_PYDEVD_VC_VARS = os.environ.get("FORCE_PYDEVD_VC_VARS")
+            if not FORCE_PYDEVD_VC_VARS:
+                FORCE_PYDEVD_VC_VARS = r"C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+                if not os.path.exists(FORCE_PYDEVD_VC_VARS):
+                    raise RuntimeError("Unable to find vcvars64.bat Please set FORCE_PYDEVD_VC_VARS environment variable to the path to the vcvars64.bat file.")
+            if FORCE_PYDEVD_VC_VARS:
+                env.update(get_environment_from_batch_command([FORCE_PYDEVD_VC_VARS], initial=os.environ.copy()))
             else:
                 raise AssertionError("Unable to setup environment for Python: %s" % (sys.version,))
 

--- a/src/debugpy/_vendored/pydevd/build_tools/pydevd_release_process.txt
+++ b/src/debugpy/_vendored/pydevd/build_tools/pydevd_release_process.txt
@@ -5,10 +5,20 @@ __version_info__ in pydevd.py
 
 Update cython-generated files (must update cython and then run build_tools/build.py on python 3.10 and 3.12)
 
+deactivate
+activate py310_64
+pip install cython --upgrade
+python build_tools/build.py
+deactivate
+activate py312_64
+pip install cython --upgrade
+python build_tools/build.py
+deactivate
+
 Create tag:
 -----------
-git tag pydev_debugger_3_4_1 -a -m "PyDev.Debugger 3.4.1"
-git push origin pydev_debugger_3_4_1
+git tag pydev_debugger_3_5_0 -a -m "PyDev.Debugger 3.5.0"
+git push origin pydev_debugger_3_5_0
 
 
 (pushing the tag does the release to PyPi now)

--- a/src/debugpy/_vendored/pydevd/pydevd.py
+++ b/src/debugpy/_vendored/pydevd/pydevd.py
@@ -174,7 +174,7 @@ if SUPPORT_GEVENT:
 if USE_CUSTOM_SYS_CURRENT_FRAMES_MAP:
     from _pydevd_bundle.pydevd_constants import constructed_tid_to_last_frame
 
-__version_info__ = (3, 4, 1)
+__version_info__ = (3, 5, 0)
 __version_info_str__ = []
 for v in __version_info__:
     __version_info_str__.append(str(v))


### PR DESCRIPTION
## Summary

Refreshes the vendored `pydevd` subrepo from upstream [fabioz/PyDev.Debugger](https://github.com/fabioz/PyDev.Debugger) `b5cfeb38` → `d6bc5f50`, bumping the bundled pydevd from **3.4.1 → 3.5.0**.

This is a **maintenance-only version refresh**. It contains no functional/behavioral changes to the debugger and no CVE-related fixes — it simply brings the vendored copy up to the latest tagged pydevd release.

## Changes (genuine upstream 2-commit delta)

| File | Change |
|------|--------|
| `pydevd.py` | `__version_info__` `(3, 4, 1)` → `(3, 5, 0)` |
| `.gitrepo` | subrepo tracked commit `b5cfeb38` → `d6bc5f50` |
| `build_tools/build.py` | upstream simplified `vcvars64` detection |
| `build_tools/pydevd_release_process.txt` | upstream release-doc update |
| `.github/workflows/pydevd-release-manylinux.yml` | upstream ARM64 manylinux wheels CI |

## Notes

- No `.pyx`/`.c` source changed, so no Cython rebuild is required.
- A spurious merge-base artifact (an unintended change in `pydevd_process_net_command_json.py` that is not part of upstream's delta) was reverted, keeping this PR to exactly the genuine upstream changes.
