### PR TITLE
Pin secure test dependency floors and drop EOL Python 3.9/3.8

### DIFF
--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -213,9 +213,6 @@ stages:
         matrix:
           py310:
             python.version: 3.10
-          py310_32:
-            python.version: 3.10
-            architecture: x86
           py311:
             python.version: 3.11
           py312:

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -213,6 +213,9 @@ stages:
         matrix:
           py310:
             python.version: 3.10
+          py310_32:
+            python.version: 3.10
+            architecture: x86
           py311:
             python.version: 3.11
           py312:

--- a/azure-pipelines/pipelines.yaml
+++ b/azure-pipelines/pipelines.yaml
@@ -29,7 +29,7 @@ stages:
           vmImage: ubuntu-latest
 
         variables:
-          python.version: "3.9"
+          python.version: "3.10"
 
         steps:
 
@@ -125,8 +125,6 @@ stages:
 
       strategy:
         matrix:
-          py39:
-            python.version: 3.9
           py310:
             python.version: 3.10
           py311:
@@ -170,8 +168,6 @@ stages:
 
       strategy:
         matrix:
-          py39:
-            python.version: 3.9
           py310:
             python.version: 3.10
           py311:
@@ -215,11 +211,6 @@ stages:
 
       strategy:
         matrix:
-          py39:
-            python.version: 3.9
-          py39_32:
-            python.version: 3.9
-            architecture: x86
           py310:
             python.version: 3.10
           py311:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = '''
 '''
 
 [tool.pyright]
-pythonVersion = "3.8"
+pythonVersion = "3.10"
 include = ["src/**", "tests/**" ]
 extraPaths = ["src/debugpy/_vendored/pydevd", "src/debugpy/_vendored/pydevd/pydevd_attach_to_process"]
 ignore = ["src/debugpy/_vendored/pydevd", "src/debugpy/_version.py"]
@@ -71,8 +71,8 @@ line-length = 88
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.8
-target-version = "py38"
+# Assume Python 3.10
+target-version = "py310"
 
 [tool.ruff.per-file-ignores]
 "tests/debugpy/test_breakpoints.py" = ["F841"]

--- a/setup.py
+++ b/setup.py
@@ -160,11 +160,9 @@ if __name__ == "__main__":
         project_urls={
             "Source": "https://github.com/microsoft/debugpy",
         },
-        python_requires=">=3.8",
+        python_requires=">=3.10",
         classifiers=[
             "Development Status :: 5 - Production/Stable",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 ## Used to run the tests:
 
-pytest
+pytest>=9.0.3  # CVE-2025-71176 (vulnerable <= 9.0.2)
 pytest-xdist
 pytest-cov
 pytest-timeout
@@ -18,7 +18,10 @@ django
 flask
 gevent
 numpy
-requests
+requests>=2.33.0  # CVE-2026-25645 (vulnerable < 2.33.0)
+# urllib3 is pulled in transitively by requests; pin a secure floor for
+# CVE-2026-44431 and CVE-2026-44432 (vulnerable 2.6.0 <= x < 2.7.0).
+urllib3>=2.7.0
 typing_extensions
 
 # Used to build pydevd attach to process binaries:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312,313,314}{,-cov}
+envlist = py{310,311,312,313,314}{,-cov}
 
 [testenv]
 deps = -rtests/requirements.txt
@@ -8,7 +8,5 @@ setenv =
     DEBUGPY_TEST=1
 commands_pre = python build_attach_binaries.py
 commands =
-    py{38,39}-!cov: python -m pytest {posargs}
-    py{38,39}-cov: python -m pytest --cov --cov-append --cov-config=.coveragerc {posargs}
     py{310,311,312,313,314}-!cov: python -Xfrozen_modules=off -m pytest {posargs}
     py{310,311,312,313,314}-cov: python -Xfrozen_modules=off -m pytest --cov --cov-append --cov-config=.coveragerc {posargs}


### PR DESCRIPTION
## Summary

Supersedes #2043. Adds the secure minimum-version floors for test dependencies that Component Governance flags as vulnerable, and drops Python 3.9/3.8 (both EOL) so those floors are installable.

The pinned versions in #2043 — `pytest>=9.0.3`, `requests>=2.33.0`, `urllib3>=2.7.0` — all require **Python >=3.10**, so on the 3.9 CI legs `pip install -r tests/requirements.txt` failed with `No matching distribution found for pytest>=9.0.3` (every 9.x release is `Requires-Python >=3.10`). Since Python 3.9 (and 3.8) are past end-of-life, the right fix is to stop testing/claiming support for them rather than weaken the security floors.

## CVEs addressed

| CVE | Package | Severity | Vulnerable | Fixed in |
|-----|---------|----------|-----------|----------|
| CVE-2026-44431 / CVE-2026-44432 | urllib3 | High | 2.6.0 – 2.6.x | 2.7.0 |
| CVE-2026-25645 | requests | Medium | < 2.33.0 | 2.33.0 |
| CVE-2025-71176 | pytest | Medium | <= 9.0.2 | 9.0.3 |

## Changes

- `tests/requirements.txt`: `pytest>=9.0.3`, `requests>=2.33.0`, `urllib3>=2.7.0` (explicit floor since it's pulled in transitively by `requests`).
- `azure-pipelines/pipelines.yaml`: remove `py39` from the Linux/macOS/Windows test matrices, remove the `py39_32` (32-bit) leg, and bump the Lint stage to Python 3.10.
- `tox.ini`: drop `py38`/`py39` from `envlist` and the per-env commands.
- `setup.py`: `python_requires=">=3.10"` and remove the 3.8/3.9 classifiers.

## Notes

- 32-bit Windows testing is dropped (it only existed on the removed 3.9 leg).
- The vendored components under `src/debugpy/_vendored/pydevd/` are out of scope here.