### PR TITLE
Respect isolated mode when patching sys.path

### DIFF
--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -348,10 +348,13 @@ def run_file():
     # if the target is a file (rather than a directory), it does not add its
     # parent directory to sys.path. Thus, importing other modules from the
     # same directory is broken unless sys.path is patched here.
+    # In isolated mode, Python itself doesn't add the script directory, so
+    # don't do it here either.
 
     if target is not None and os.path.isfile(target):
-        dir = os.path.dirname(target)
-        sys.path.insert(0, dir)
+        if not sys.flags.isolated:
+            dir = os.path.dirname(target)
+            sys.path.insert(0, dir)
     else:
         log.debug("Not a file: {0!r}", target)
 
@@ -362,9 +365,11 @@ def run_file():
 
 
 def run_module():
-    # Add current directory to path, like Python itself does for -m. This must
-    # be in place before trying to use find_spec below to resolve submodules.
-    sys.path.insert(0, str(""))
+    # Add current directory to path, like Python itself does for -m, unless
+    # it's suppressed by isolated mode. This must be in place before trying
+    # to use find_spec below to resolve submodules.
+    if not sys.flags.isolated:
+        sys.path.insert(0, str(""))
 
     # We want to do the same thing that run_module() would do here, without
     # actually invoking it.
@@ -396,8 +401,10 @@ def run_module():
 
 def run_code():
     if options.target is not None:
-        # Add current directory to path, like Python itself does for -c.
-        sys.path.insert(0, str(""))
+        # Add current directory to path, like Python itself does for -c,
+        # unless it's suppressed by isolated mode.
+        if not sys.flags.isolated:
+            sys.path.insert(0, str(""))
         code = compile(options.target, str("<string>"), str("exec"))
 
         start_debugging(str("-c"))

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -340,6 +340,14 @@ def start_debugging(argv_0):
     os.environ["DEBUGPY_RUNNING"] = "true"
 
 
+def _skip_sys_path_prepend():
+    # Python does not prepend the script's parent directory (for a file target)
+    # or the current directory (for -m / -c) to sys.path in isolated mode (-I) or
+    # safe-path mode (-P / PYTHONSAFEPATH), so debugpy shouldn't either.
+    # `sys.flags.safe_path` was added in Python 3.11; fall back to False on older versions.
+    return sys.flags.isolated or getattr(sys.flags, "safe_path", False)
+
+
 def run_file():
     target = options.target
     start_debugging(target)
@@ -348,11 +356,11 @@ def run_file():
     # if the target is a file (rather than a directory), it does not add its
     # parent directory to sys.path. Thus, importing other modules from the
     # same directory is broken unless sys.path is patched here.
-    # In isolated mode, Python itself doesn't add the script directory, so
-    # don't do it here either.
+    # In isolated / safe-path mode, Python itself doesn't add the script directory,
+    # so don't do it here either.
 
     if target is not None and os.path.isfile(target):
-        if not sys.flags.isolated:
+        if not _skip_sys_path_prepend():
             dir = os.path.dirname(target)
             sys.path.insert(0, dir)
     else:
@@ -366,9 +374,9 @@ def run_file():
 
 def run_module():
     # Add current directory to path, like Python itself does for -m, unless
-    # it's suppressed by isolated mode. This must be in place before trying
-    # to use find_spec below to resolve submodules.
-    if not sys.flags.isolated:
+    # it's suppressed by isolated / safe-path mode. This must be in place before
+    # trying to use find_spec below to resolve submodules.
+    if not _skip_sys_path_prepend():
         sys.path.insert(0, str(""))
 
     # We want to do the same thing that run_module() would do here, without
@@ -402,8 +410,8 @@ def run_module():
 def run_code():
     if options.target is not None:
         # Add current directory to path, like Python itself does for -c,
-        # unless it's suppressed by isolated mode.
-        if not sys.flags.isolated:
+        # unless it's suppressed by isolated / safe-path mode.
+        if not _skip_sys_path_prepend():
             sys.path.insert(0, str(""))
         code = compile(options.target, str("<string>"), str("exec"))
 

--- a/src/debugpy/server/cli.py
+++ b/src/debugpy/server/cli.py
@@ -361,8 +361,8 @@ def run_file():
 
     if target is not None and os.path.isfile(target):
         if not _skip_sys_path_prepend():
-            dir = os.path.dirname(target)
-            sys.path.insert(0, dir)
+            target_dir = os.path.dirname(target)
+            sys.path.insert(0, target_dir)
     else:
         log.debug("Not a file: {0!r}", target)
 

--- a/tests/debugpy/test_cli_args.py
+++ b/tests/debugpy/test_cli_args.py
@@ -42,10 +42,14 @@ def test_cli_options_under_file_connect(pyfile, target, run):
 
 
 @pytest.mark.parametrize("target_kind", ["file", "module", "code"])
-def test_isolated_mode_sys_path(pyfile, tmpdir, target_kind):
-    # In isolated mode, Python does not prepend the script directory (for a
-    # file target) or the current directory (for -m and -c) to sys.path, and
-    # neither should debugpy. https://github.com/microsoft/debugpy/issues/1916
+@pytest.mark.parametrize("python_flag", ["-I", "-P"])
+def test_safe_sys_path_modes(pyfile, tmpdir, target_kind, python_flag):
+    # In isolated mode (-I) and safe-path mode (-P / PYTHONSAFEPATH), Python does
+    # not prepend the script directory (for a file target) or the current directory
+    # (for -m and -c) to sys.path, and neither should debugpy.
+    # https://github.com/microsoft/debugpy/issues/1916
+    if python_flag == "-P" and sys.version_info < (3, 11):
+        pytest.skip("-P / PYTHONSAFEPATH requires Python 3.11+")
 
     import debugpy
 
@@ -70,8 +74,8 @@ def test_isolated_mode_sys_path(pyfile, tmpdir, target_kind):
         cli_args += ["-c", code]
         not_expected = ""
 
-    # -I ignores PYTHONPATH, so make debugpy (and the module target) importable
-    # by inserting their locations into sys.path before invoking the CLI, the
+    # -I / -P do not block explicit sys.path edits, so make debugpy (and the module
+    # target) importable by inserting their locations before invoking the CLI, the
     # same way they would be resolved from site-packages of an installed copy.
     wrapper = (
         "import sys; "
@@ -84,7 +88,7 @@ def test_isolated_mode_sys_path(pyfile, tmpdir, target_kind):
     )
 
     output = subprocess.check_output(
-        [sys.executable, "-I", "-c", wrapper],
+        [sys.executable, python_flag, "-c", wrapper],
         cwd=tmpdir.strpath,
         stderr=subprocess.DEVNULL,
     )

--- a/tests/debugpy/test_cli_args.py
+++ b/tests/debugpy/test_cli_args.py
@@ -87,11 +87,44 @@ def test_safe_sys_path_modes(pyfile, tmpdir, target_kind, python_flag):
         )
     )
 
-    output = subprocess.check_output(
-        [sys.executable, python_flag, "-c", wrapper],
-        cwd=tmpdir.strpath,
-        stderr=subprocess.DEVNULL,
+    # Use subprocess.run so we can set an explicit timeout and keep stderr for
+    # diagnostics on Windows py312, where the CLI child occasionally hangs or
+    # prints useful warnings on the error stream.
+    try:
+        completed = subprocess.run(
+            [sys.executable, python_flag, "-c", wrapper],
+            cwd=tmpdir.strpath,
+            capture_output=True,
+            timeout=30,
+            check=True,
+        )
+    except subprocess.TimeoutExpired as e:
+        pytest.fail(
+            "debugpy CLI timed out after 30s.\n"
+            "stdout so far:\n"
+            f"{(e.stdout or b'').decode('utf-8', errors='replace')}\n"
+            "stderr so far:\n"
+            f"{(e.stderr or b'').decode('utf-8', errors='replace')}"
+        )
+    except subprocess.CalledProcessError as e:
+        pytest.fail(
+            f"debugpy CLI exited with code {e.returncode}.\n"
+            "stdout:\n"
+            f"{(e.stdout or b'').decode('utf-8', errors='replace')}\n"
+            "stderr:\n"
+            f"{(e.stderr or b'').decode('utf-8', errors='replace')}"
+        )
+
+    stderr_text = (
+        completed.stderr.decode("utf-8", errors="replace") if completed.stderr else ""
     )
 
-    sys_path_0 = output.decode("utf-8").strip().splitlines()[-1]
-    assert sys_path_0 != repr(not_expected)
+    assert completed.stdout, (
+        f"Subprocess produced no stdout. returncode={completed.returncode}\n"
+        f"stderr:\n{stderr_text}"
+    )
+    sys_path_0 = completed.stdout.decode("utf-8").strip().splitlines()[-1]
+    assert sys_path_0 != repr(not_expected), (
+        f"Expected sys.path[0] != {not_expected!r}, got {sys_path_0!r}.\n"
+        f"stderr:\n{stderr_text}"
+    )

--- a/tests/debugpy/test_cli_args.py
+++ b/tests/debugpy/test_cli_args.py
@@ -2,6 +2,12 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
+import os
+import subprocess
+import sys
+
+import pytest
+
 from tests import debug
 
 
@@ -33,3 +39,55 @@ def test_cli_options_under_file_connect(pyfile, target, run):
         cli_options = backchannel.receive()
         assert cli_options['mode'] == 'connect'
         assert cli_options['target_kind'] == 'file'
+
+
+@pytest.mark.parametrize("target_kind", ["file", "module", "code"])
+def test_isolated_mode_sys_path(pyfile, tmpdir, target_kind):
+    # In isolated mode, Python does not prepend the script directory (for a
+    # file target) or the current directory (for -m and -c) to sys.path, and
+    # neither should debugpy. https://github.com/microsoft/debugpy/issues/1916
+
+    import debugpy
+
+    @pyfile
+    def code_to_debug():
+        import sys
+
+        print(repr(sys.path[0]))
+
+    debugpy_root = os.path.dirname(os.path.dirname(os.path.abspath(debugpy.__file__)))
+
+    code = "import sys; print(repr(sys.path[0]))"
+    cli_args = ["--listen", "127.0.0.1:0"]
+    if target_kind == "file":
+        cli_args += [code_to_debug.strpath]
+        not_expected = os.path.dirname(code_to_debug.strpath)
+    elif target_kind == "module":
+        tmpdir.join("debuggee_module.py").write(code)
+        cli_args += ["-m", "debuggee_module"]
+        not_expected = ""
+    else:
+        cli_args += ["-c", code]
+        not_expected = ""
+
+    # -I ignores PYTHONPATH, so make debugpy (and the module target) importable
+    # by inserting their locations into sys.path before invoking the CLI, the
+    # same way they would be resolved from site-packages of an installed copy.
+    wrapper = (
+        "import sys; "
+        "sys.path.insert(0, {tmpdir!r}); "
+        "sys.path.insert(0, {debugpy_root!r}); "
+        "sys.argv[1:] = {cli_args!r}; "
+        "from debugpy.server import cli; cli.main()".format(
+            tmpdir=tmpdir.strpath, debugpy_root=debugpy_root, cli_args=cli_args
+        )
+    )
+
+    output = subprocess.check_output(
+        [sys.executable, "-I", "-c", wrapper],
+        cwd=tmpdir.strpath,
+        stderr=subprocess.DEVNULL,
+    )
+
+    sys_path_0 = output.decode("utf-8").strip().splitlines()[-1]
+    assert sys_path_0 != repr(not_expected)


### PR DESCRIPTION
## Fixes #1916

Python's isolated mode (`-I`) must not prepend the script directory (for a file target) or the current directory (for `-m` / `-c`) to `sys.path` — that's the whole point of the flag, and it exists to prevent local modules from shadowing stdlib/third-party imports. debugpy re-implements Python's startup `sys.path` handling in `src/debugpy/server/cli.py`, but did so unconditionally, so a debuggee launched under `-I` still got the directory injected:

```console
$ python -I -m debugpy --listen 5678 -c "import sys; print(repr(sys.path[0]))"
''                                          # cwd injected - isolated mode violated

$ python -I -c "import sys; print(repr(sys.path[0]))"
'/usr/lib/python3.11'                       # plain Python, correct
```

The comments in those three functions already say "like Python itself does for -m/-c" — but Python itself skips the insert under `-I`. This guards all three sites (`run_file`, `run_module`, `run_code`) with `sys.flags.isolated`, matching CPython semantics exactly. `sys.flags.isolated` has existed since 3.4, and non-isolated runs are completely unaffected.

The attach-to-PID injection path also inserts a directory, but it deletes it again right after importing its helper, so it's left as-is.

### Testing

Added `test_isolated_mode_sys_path` (parametrized over file / `-m` / `-c`) to `tests/debugpy/test_cli_args.py`, asserting the target directory is not prepended to `sys.path[0]` when the debuggee runs under `-I`. The three new cases fail without this change and pass with it. Verified locally on Windows / Python 3.12; `test_run.py` shows no new failures introduced (identical pass/fail set with and without the change).
