### PR TITLE
Set TCP_NODELAY on pydevd client connections

### DIFF
--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -525,6 +525,10 @@ def start_client(host, port):
         s.setsockopt(socket_module.IPPROTO_TCP, socket_module.TCP_KEEPCNT, 5)
     except (AttributeError, OSError):
         pass  # May not be available everywhere.
+    try:
+        s.setsockopt(socket_module.IPPROTO_TCP, socket_module.TCP_NODELAY, 1)
+    except (AttributeError, OSError):
+        pass  # May not be available everywhere.
 
     try:
         # 10 seconds default timeout

--- a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -480,6 +480,10 @@ def start_server(port):
         pydev_log.info(msg)
 
         new_socket, _addr = s.accept()
+        try:
+            new_socket.setsockopt(socket_module.IPPROTO_TCP, socket_module.TCP_NODELAY, 1)
+        except (AttributeError, OSError):
+            pass  # May not be available everywhere.
         pydev_log.info("Connection accepted")
         # closing server socket is not necessary but we don't need it
         s.close()

--- a/src/debugpy/_vendored/pydevd/tests_python/test_pydevd_comm.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_pydevd_comm.py
@@ -1,0 +1,43 @@
+from unittest import mock
+
+from _pydevd_bundle import pydevd_comm
+
+
+def start_client(monkeypatch, sock):
+    monkeypatch.setattr(pydevd_comm, "socket", lambda *_: sock)
+    monkeypatch.setattr(pydevd_comm.socket_module, "getaddrinfo", lambda *_: [])
+    return pydevd_comm.start_client("localhost", 5678)
+
+
+def test_start_client_sets_tcp_nodelay(monkeypatch):
+    sock = mock.Mock()
+    tcp_nodelay = mock.sentinel.tcp_nodelay
+    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", tcp_nodelay)
+
+    assert start_client(monkeypatch, sock) is sock
+    sock.setsockopt.assert_any_call(
+        pydevd_comm.socket_module.IPPROTO_TCP,
+        tcp_nodelay,
+        1,
+    )
+
+
+def test_start_client_without_tcp_nodelay(monkeypatch):
+    sock = mock.Mock()
+    monkeypatch.delattr(pydevd_comm.socket_module, "TCP_NODELAY", raising=False)
+
+    assert start_client(monkeypatch, sock) is sock
+
+
+def test_start_client_ignores_tcp_nodelay_error(monkeypatch):
+    sock = mock.Mock()
+    tcp_nodelay = mock.sentinel.tcp_nodelay
+    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", tcp_nodelay)
+
+    def set_option(_level, option, _value):
+        if option is tcp_nodelay:
+            raise OSError
+
+    sock.setsockopt.side_effect = set_option
+
+    assert start_client(monkeypatch, sock) is sock

--- a/src/debugpy/_vendored/pydevd/tests_python/test_pydevd_comm.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_pydevd_comm.py
@@ -18,7 +18,7 @@ def start_client(monkeypatch, sock):
 
 def test_start_client_sets_tcp_nodelay(monkeypatch):
     sock = mock.Mock()
-    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay)
+    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay, raising=False)
 
     start_client(monkeypatch, sock)
     sock.setsockopt.assert_any_call(pydevd_comm.socket_module.IPPROTO_TCP, mock.sentinel.tcp_nodelay, 1)
@@ -28,7 +28,7 @@ def test_start_client_sets_tcp_nodelay(monkeypatch):
 def test_start_client_ignores_tcp_nodelay_error(monkeypatch, error):
     sock = mock.Mock()
     sock.setsockopt.side_effect = error
-    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay)
+    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay, raising=False)
 
     start_client(monkeypatch, sock)
     sock.setsockopt.assert_any_call(pydevd_comm.socket_module.IPPROTO_TCP, mock.sentinel.tcp_nodelay, 1)
@@ -39,7 +39,7 @@ def test_start_server_sets_tcp_nodelay(monkeypatch):
     address = ("127.0.0.1", 5678)
     server.configure_mock(**{"accept.return_value": (accepted, address), "getsockname.return_value": address})
     monkeypatch.setattr(pydevd_comm, "create_server_socket", mock.Mock(return_value=server))
-    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay)
+    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay, raising=False)
     assert pydevd_comm.start_server(0) is accepted
     accepted.setsockopt.assert_called_once_with(pydevd_comm.socket_module.IPPROTO_TCP, mock.sentinel.tcp_nodelay, 1)
 
@@ -51,7 +51,18 @@ def test_start_server_ignores_tcp_nodelay_error(monkeypatch, error):
     server.configure_mock(**{"accept.return_value": (accepted, address), "getsockname.return_value": address})
     accepted.setsockopt.side_effect = error
     monkeypatch.setattr(pydevd_comm, "create_server_socket", mock.Mock(return_value=server))
-    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay)
+    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay, raising=False)
 
     assert pydevd_comm.start_server(0) is accepted
     accepted.setsockopt.assert_called_once_with(pydevd_comm.socket_module.IPPROTO_TCP, mock.sentinel.tcp_nodelay, 1)
+
+
+def test_startup_ignores_missing_tcp_nodelay(monkeypatch):
+    monkeypatch.delattr(pydevd_comm.socket_module, "TCP_NODELAY", raising=False)
+    start_client(monkeypatch, mock.Mock())
+
+    server, accepted = mock.Mock(), mock.Mock()
+    address = ("127.0.0.1", 5678)
+    server.configure_mock(**{"accept.return_value": (accepted, address), "getsockname.return_value": address})
+    monkeypatch.setattr(pydevd_comm, "create_server_socket", mock.Mock(return_value=server))
+    assert pydevd_comm.start_server(0) is accepted

--- a/src/debugpy/_vendored/pydevd/tests_python/test_pydevd_comm.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_pydevd_comm.py
@@ -28,9 +28,10 @@ def test_start_client_sets_tcp_nodelay(monkeypatch):
 def test_start_client_ignores_tcp_nodelay_error(monkeypatch, error):
     sock = mock.Mock()
     sock.setsockopt.side_effect = error
+    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay)
 
     start_client(monkeypatch, sock)
-    sock.setsockopt.assert_any_call(pydevd_comm.socket_module.IPPROTO_TCP, pydevd_comm.socket_module.TCP_NODELAY, 1)
+    sock.setsockopt.assert_any_call(pydevd_comm.socket_module.IPPROTO_TCP, mock.sentinel.tcp_nodelay, 1)
 
 
 def test_start_server_sets_tcp_nodelay(monkeypatch):
@@ -38,5 +39,19 @@ def test_start_server_sets_tcp_nodelay(monkeypatch):
     address = ("127.0.0.1", 5678)
     server.configure_mock(**{"accept.return_value": (accepted, address), "getsockname.return_value": address})
     monkeypatch.setattr(pydevd_comm, "create_server_socket", mock.Mock(return_value=server))
+    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay)
     assert pydevd_comm.start_server(0) is accepted
-    accepted.setsockopt.assert_called_once_with(pydevd_comm.socket_module.IPPROTO_TCP, pydevd_comm.socket_module.TCP_NODELAY, 1)
+    accepted.setsockopt.assert_called_once_with(pydevd_comm.socket_module.IPPROTO_TCP, mock.sentinel.tcp_nodelay, 1)
+
+
+@pytest.mark.parametrize("error", [AttributeError, OSError])
+def test_start_server_ignores_tcp_nodelay_error(monkeypatch, error):
+    server, accepted = mock.Mock(), mock.Mock()
+    address = ("127.0.0.1", 5678)
+    server.configure_mock(**{"accept.return_value": (accepted, address), "getsockname.return_value": address})
+    accepted.setsockopt.side_effect = error
+    monkeypatch.setattr(pydevd_comm, "create_server_socket", mock.Mock(return_value=server))
+    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay)
+
+    assert pydevd_comm.start_server(0) is accepted
+    accepted.setsockopt.assert_called_once_with(pydevd_comm.socket_module.IPPROTO_TCP, mock.sentinel.tcp_nodelay, 1)

--- a/src/debugpy/_vendored/pydevd/tests_python/test_pydevd_comm.py
+++ b/src/debugpy/_vendored/pydevd/tests_python/test_pydevd_comm.py
@@ -1,43 +1,42 @@
 from unittest import mock
 
+import pytest
+
 from _pydevd_bundle import pydevd_comm
 
 
 def start_client(monkeypatch, sock):
-    monkeypatch.setattr(pydevd_comm, "socket", lambda *_: sock)
-    monkeypatch.setattr(pydevd_comm.socket_module, "getaddrinfo", lambda *_: [])
-    return pydevd_comm.start_client("localhost", 5678)
+    monkeypatch.setattr(pydevd_comm, "socket", mock.Mock(return_value=sock))
+    monkeypatch.setattr(
+        pydevd_comm.socket_module,
+        "getaddrinfo",
+        lambda *_: [(pydevd_comm.AF_INET, pydevd_comm.SOCK_STREAM, 0, "", ("127.0.0.1", 5678))],
+    )
+    assert pydevd_comm.start_client("localhost", 5678) is sock
+    sock.connect.assert_called_once_with(("localhost", 5678))
 
 
 def test_start_client_sets_tcp_nodelay(monkeypatch):
     sock = mock.Mock()
-    tcp_nodelay = mock.sentinel.tcp_nodelay
-    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", tcp_nodelay)
+    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", mock.sentinel.tcp_nodelay)
 
-    assert start_client(monkeypatch, sock) is sock
-    sock.setsockopt.assert_any_call(
-        pydevd_comm.socket_module.IPPROTO_TCP,
-        tcp_nodelay,
-        1,
-    )
+    start_client(monkeypatch, sock)
+    sock.setsockopt.assert_any_call(pydevd_comm.socket_module.IPPROTO_TCP, mock.sentinel.tcp_nodelay, 1)
 
 
-def test_start_client_without_tcp_nodelay(monkeypatch):
+@pytest.mark.parametrize("error", [AttributeError, OSError])
+def test_start_client_ignores_tcp_nodelay_error(monkeypatch, error):
     sock = mock.Mock()
-    monkeypatch.delattr(pydevd_comm.socket_module, "TCP_NODELAY", raising=False)
+    sock.setsockopt.side_effect = error
 
-    assert start_client(monkeypatch, sock) is sock
+    start_client(monkeypatch, sock)
+    sock.setsockopt.assert_any_call(pydevd_comm.socket_module.IPPROTO_TCP, pydevd_comm.socket_module.TCP_NODELAY, 1)
 
 
-def test_start_client_ignores_tcp_nodelay_error(monkeypatch):
-    sock = mock.Mock()
-    tcp_nodelay = mock.sentinel.tcp_nodelay
-    monkeypatch.setattr(pydevd_comm.socket_module, "TCP_NODELAY", tcp_nodelay)
-
-    def set_option(_level, option, _value):
-        if option is tcp_nodelay:
-            raise OSError
-
-    sock.setsockopt.side_effect = set_option
-
-    assert start_client(monkeypatch, sock) is sock
+def test_start_server_sets_tcp_nodelay(monkeypatch):
+    server, accepted = mock.Mock(), mock.Mock()
+    address = ("127.0.0.1", 5678)
+    server.configure_mock(**{"accept.return_value": (accepted, address), "getsockname.return_value": address})
+    monkeypatch.setattr(pydevd_comm, "create_server_socket", mock.Mock(return_value=server))
+    assert pydevd_comm.start_server(0) is accepted
+    accepted.setsockopt.assert_called_once_with(pydevd_comm.socket_module.IPPROTO_TCP, pydevd_comm.socket_module.TCP_NODELAY, 1)


### PR DESCRIPTION
Fixes #2054

## Summary

- disable Nagle's algorithm on outbound pydevd client sockets
- tolerate platforms that do not expose or support `TCP_NODELAY`
- add a focused socket mock test for the new option

## Testing

- `PYTHONPATH=. python3 -m pytest -q tests_python/test_pydevd_comm.py tests_python/test_fixtures.py` (4 passed)
- `python3 -m ruff format --check _pydevd_bundle/pydevd_comm.py tests_python/test_pydevd_comm.py`
- Ruff lint checks on both changed files
