### PR TITLE
Document Python configuration for embedded hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ The following command will ignore subprocesses started by the debugged process.
 
 For full details, see the [API reference](https://github.com/microsoft/debugpy/wiki/API-Reference).
 
+### Embedded Python hosts
+`debugpy.listen()` uses `sys.executable` to start the debug adapter by default. If Python is embedded in another application, set the path to a Python interpreter before starting the listener:
+```python
+import debugpy
+debugpy.configure(python="/path/to/python")
+debugpy.listen(("localhost", 5678))
+```
+
 ### Enabling debugging
 At the beginning of your script, import debugpy, and call `debugpy.listen()` to start the debug adapter, passing a `(host, port)` tuple as the first argument.
 ```python

--- a/src/debugpy/public_api.py
+++ b/src/debugpy/public_api.py
@@ -76,6 +76,14 @@ def configure(__properties: dict[str, typing.Any] | None = None, **kwargs) -> No
     "attach" request, because they must be applied as early as possible
     in the process being debugged.
 
+    When Python is embedded in another application, ``sys.executable``
+    may point to the host executable instead of a Python interpreter. Set
+    the ``python`` property to the interpreter that debugpy should use to
+    start its adapter process, before calling ``listen``::
+
+        debugpy.configure(python="/path/to/python")
+        debugpy.listen(...)
+
     For example, a "launch" configuration with subprocess debugging
     disabled can be defined entirely in JSON::
 


### PR DESCRIPTION
Fixes #1097

## Summary
- document that `debugpy.configure(python=...)` selects the interpreter used to launch the adapter process
- add an embedded-host example that configures the interpreter before `debugpy.listen()`

## Tests
- `python3 -m flake8 src/debugpy/public_api.py`
- `python3 -m ruff check src/debugpy/public_api.py`
- `pytest -n0 tests/debugpy/test_api.py tests/debugpy/test_docstrings.py` (3 passed)