### PR TITLE
Use non-deprecated wx GUI event loop

### DIFF
--- a/src/debugpy/_vendored/pydevd/pydev_ipython/inputhookwx.py
+++ b/src/debugpy/_vendored/pydevd/pydev_ipython/inputhookwx.py
@@ -44,7 +44,7 @@ def inputhook_wx1():
             # Make a temporary event loop and process system events until
             # there are no more waiting, then allow idle events (which
             # will also deal with pending or posted wx events.)
-            evtloop = wx.EventLoop()  # @UndefinedVariable
+            evtloop = wx.GUIEventLoop()  # @UndefinedVariable
             ea = wx.EventLoopActivator(evtloop)  # @UndefinedVariable
             while evtloop.Pending():
                 evtloop.Dispatch()
@@ -66,7 +66,7 @@ class EventLoopTimer(wx.Timer):  # @UndefinedVariable
 
 class EventLoopRunner(object):
     def Run(self, time):
-        self.evtloop = wx.EventLoop()  # @UndefinedVariable
+        self.evtloop = wx.GUIEventLoop()  # @UndefinedVariable
         self.timer = EventLoopTimer(self.check_stdin)
         self.timer.Start(time)
         self.evtloop.Run()
@@ -128,7 +128,7 @@ def inputhook_wx3():
             if not callable(signal.getsignal(signal.SIGINT)):
                 signal.signal(signal.SIGINT, signal.default_int_handler)
 
-            evtloop = wx.EventLoop()  # @UndefinedVariable
+            evtloop = wx.GUIEventLoop()  # @UndefinedVariable
             ea = wx.EventLoopActivator(evtloop)  # @UndefinedVariable
             t = clock()
             while not stdin_ready():


### PR DESCRIPTION
Fixes #1901

## Summary

- replace the deprecated wx.EventLoop class in all wx input-hook paths
- use wx.GUIEventLoop as recommended by wxPython

## Testing

- PYTHONPATH=. python3 -m pytest -q tests/test_pydev_ipython_011.py (15 passed)
- python3 -m ruff check src/debugpy/_vendored/pydevd/pydev_ipython/inputhookwx.py
- python3 -m ruff format --check src/debugpy/_vendored/pydevd/pydev_ipython/inputhookwx.py
- git diff --check